### PR TITLE
Fix cmux interactive subagent launches

### DIFF
--- a/src/subagents/index.ts
+++ b/src/subagents/index.ts
@@ -23,6 +23,7 @@ import {
 	muxSetupHint,
 	createSurface,
 	sendCommand,
+	sendShellCommand,
 	interruptSurface,
 	pollForExit,
 	consumeSubagentExitSignal,
@@ -2188,7 +2189,7 @@ async function launchSubagent(
 
 	const piCommand = cdPrefix + envPrefix + parts.join(" ");
 	const command = `${piCommand}; printf '__SUBAGENT_DONE_'${exitStatusVar()}'__\\n' | tee ${shellEscape(doneSentinelFile)}`;
-	sendCommand(surface, command);
+	sendShellCommand(surface, command);
 
 	const running: RunningSubagent = {
 		id,
@@ -3172,7 +3173,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 				);
 				const resumeEnvPrefix = `${resumeEnvParts.join(" ")} `;
 				const command = `${resumeEnvPrefix}${parts.join(" ")}${cleanupMsgFile ? `; rm -f ${shellEscape(cleanupMsgFile)}` : ""}; echo '__SUBAGENT_DONE_'${exitStatusVar()}'__'`;
-				sendCommand(surface, command);
+				sendShellCommand(surface, command);
 
 				const id = Math.random().toString(16).slice(2, 10);
 				const running: RunningSubagent = {

--- a/src/subagents/mux.ts
+++ b/src/subagents/mux.ts
@@ -1,6 +1,6 @@
 import { execSync, execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 
@@ -433,6 +433,40 @@ export function sendCommand(surface: string, command: string): void {
 
   zellijActionSync(["write-chars", command], surface);
   zellijActionSync(["write", "13"], surface);
+}
+
+function stageShellCommand(command: string): string {
+  const shell = (process.env.SHELL ?? "/bin/sh").trim() || "/bin/sh";
+  const ext = isFishShell() ? ".fish" : ".sh";
+  const scriptPath = join(
+    tmpdir(),
+    `pi-subagent-cmux-${Date.now()}-${Math.random().toString(36).slice(2)}${ext}`,
+  );
+  writeFileSync(scriptPath, `#!${shell}\n${command}\n`, "utf8");
+  chmodSync(scriptPath, 0o700);
+  return scriptPath;
+}
+
+function buildStagedShellCommand(scriptPath: string): string {
+  return `${shellEscape(scriptPath)}; rm -f ${shellEscape(scriptPath)}`;
+}
+
+export function sendShellCommand(surface: string, command: string): void {
+  const backend = requireMuxBackend();
+  if (backend !== "cmux") {
+    sendCommand(surface, command);
+    return;
+  }
+
+  const scriptPath = stageShellCommand(command);
+  try {
+    sendCommand(surface, buildStagedShellCommand(scriptPath));
+  } catch (error) {
+    try {
+      rmSync(scriptPath, { force: true });
+    } catch {}
+    throw error;
+  }
 }
 
 export function interruptSurface(surface: string): void {

--- a/test/test.ts
+++ b/test/test.ts
@@ -35,6 +35,7 @@ import {
   readScreen,
   readScreenAsync,
   renameCurrentTab,
+  sendShellCommand,
   renameWorkspace,
   sendCommand,
   shellEscape,
@@ -3057,6 +3058,51 @@ esac
       assert.match(log, /send/);
       assert.match(log, /read-screen/);
       assert.match(log, /close-surface/);
+    });
+
+    it("stages long cmux shell commands through a temp script", () => {
+      const dir = createTestDir();
+      const logFile = join(dir, "cmux-stage.log");
+      writeExecutable(
+        dir,
+        "cmux",
+        `#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_CMUX_LOG"
+`,
+      );
+
+      process.env.PATH = `${dir}:${ORIGINAL_ENV.PATH}`;
+      process.env.PI_SUBAGENT_MUX = "cmux";
+      process.env.CMUX_SOCKET_PATH = "/tmp/fake-cmux.sock";
+      process.env.CMUX_WORKSPACE_ID = "workspace:8";
+      process.env.FAKE_CMUX_LOG = logFile;
+      process.env.SHELL = "/bin/sh";
+
+      let stagedPath: string | null = null;
+      try {
+        const longCommand = `FILLER='${"x".repeat(8000)}' pi --session /tmp/session.jsonl @/tmp/prompt.md; echo '__SUBAGENT_DONE_'$?'__'`;
+        sendShellCommand("surface:42", longCommand);
+
+        const log = readFileSync(logFile, "utf8");
+        assert.match(log, /send --surface surface:42/);
+        assert.doesNotMatch(log, /FILLER='x{100}/);
+        assert.match(log, /pi-subagent-cmux-/);
+        assert.match(log, /rm -f/);
+
+        const pathMatch = log.match(/(\/[^\s']*pi-subagent-cmux-[^\s']+\.(?:sh|fish))/);
+        assert.ok(pathMatch);
+        stagedPath = pathMatch[1];
+        assert.equal(existsSync(stagedPath), true);
+
+        const stagedCommand = readFileSync(stagedPath, "utf8");
+        assert.match(stagedCommand, /^#!\/bin\/sh\n/);
+        assert.match(stagedCommand, /FILLER='x{100}/);
+        assert.match(stagedCommand, /pi --session \/tmp\/session\.jsonl/);
+        assert.match(stagedCommand, /__SUBAGENT_DONE_/);
+      } finally {
+        if (stagedPath && existsSync(stagedPath)) rmSync(stagedPath, { force: true });
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
 
     it("exercises the wezterm backend with a fake wezterm binary", async () => {


### PR DESCRIPTION
## Summary
- add a cmux-only `sendShellCommand()` helper that stages long launch commands through a temp script
- switch interactive subagent launch and resume paths to use the staged cmux helper
- add regression coverage for staged cmux command delivery

## Testing
- `npm test` *(repo still has 2 pre-existing unrelated failures in session-dir path normalization and tmux environment detection; new cmux regression test passes)*
- real cmux long-command smoke via `sendShellCommand()` with an 8k payload
- real pi-in-cmux interactive subagent launch: child completed and wrote `notes/cmux-live-ok.md`
- real pi-in-cmux `subagent_resume` + `subagent_wait`: resumed child completed with `CMUX_RESUME_OK` and parent finished with `CMUX_RESUME_ROOT_OK`