### PR TITLE
Add configurable subagent pi launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ pi install git:github.com/edxeth/pi-subagents
 
 That is the difference between “subagents exist” and “subagents are usable.”
 
+## Launching children through a wrapper
+
+By default, child sessions are launched with the normal `pi` command or, when possible, the same bundled executable as the parent process. If your pi runtime is wrapped by another launcher, opt in explicitly with:
+
+```bash
+PI_SUBAGENT_PI_COMMAND="tia pi" tia pi
+```
+
+This makes both interactive subagents and resumed sessions launch through `tia pi` without changing behavior for users who run stock `pi`. The value is parsed as command words, so quoted paths are supported:
+
+```bash
+PI_SUBAGENT_PI_COMMAND="'/path with spaces/tia' pi" pi
+```
+
 ## Why it exists
 
 A scout, a reviewer, and an implementation worker are not the same thing.

--- a/src/subagents/index.ts
+++ b/src/subagents/index.ts
@@ -743,6 +743,10 @@ function getPiInvocation(args: string[]): { command: string; args: string[] } {
 		return { command: parts[0], args: [...parts.slice(1), ...args] };
 	}
 
+	if (isTiaParentProcess()) {
+		return { command: "tia", args: ["pi", ...args] };
+	}
+
 	const currentScript = process.argv[1];
 	if (currentScript && existsSync(currentScript)) {
 		return { command: process.execPath, args: [currentScript, ...args] };
@@ -760,12 +764,50 @@ function getPiShellParts(args: string[]): string[] {
 	return [shellEscape(invocation.command), ...invocation.args.map((arg) => shellEscape(arg))];
 }
 
+function isTiaParentProcess(): boolean {
+	if (process.env.TIA_ACTIVE === "1") return true;
+	const command = process.env.TIA_COMMAND?.trim();
+	if (command === "tia pi" || command === "tia") return true;
+	const packageDir = process.env.PI_PACKAGE_DIR ?? "";
+	const agentDir = process.env.PI_CODING_AGENT_DIR ?? "";
+	return packageDir.includes("/tia/") || agentDir.includes("/tia/pi-agent");
+}
+
+function shouldUnsetInheritedTiaEnv(invocation: { command: string; args: string[] }): boolean {
+	const commandName = basename(invocation.command).toLowerCase();
+	const launchedViaEnv = commandName === "env" && invocation.args.some((arg) => basename(arg).toLowerCase() === "pi");
+	const launchedViaPi = commandName === "pi" || commandName === "pi.exe" || launchedViaEnv;
+	if (!launchedViaPi) return false;
+	const packageDir = process.env.PI_PACKAGE_DIR ?? "";
+	const agentDir = process.env.PI_CODING_AGENT_DIR ?? "";
+	return packageDir.includes("/tia/") || agentDir.includes("/tia/pi-agent");
+}
+
+function getSubagentChildProcessEnv(
+	invocation: { command: string; args: string[] },
+	envVars: Record<string, string>,
+): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = { ...process.env, ...envVars };
+	if (shouldUnsetInheritedTiaEnv(invocation)) {
+		delete env.PI_PACKAGE_DIR;
+		delete env.PI_CODING_AGENT_DIR;
+	}
+	return env;
+}
+
 export function getPiInvocationForTest(args: string[]) {
 	return getPiInvocation(args);
 }
 
 export function getPiShellPartsForTest(args: string[]) {
 	return getPiShellParts(args);
+}
+
+export function getSubagentChildProcessEnvForTest(
+	invocation: { command: string; args: string[] },
+	envVars: Record<string, string>,
+) {
+	return getSubagentChildProcessEnv(invocation, envVars);
 }
 
 /**
@@ -1291,11 +1333,11 @@ function getStartedSubagentResult(running: RunningSubagent) {
 			{
 				type: "text" as const,
 				text:
-					`Sub-agent "${running.name}" launched ${isAsync ? "async" : "sync"}. ` +
+					`Sub-agent "${running.name}" launched ${isAsync ? "async" : "sync"} with id ${running.id}. ` +
 					(isAsync
 						? `Results will be delivered automatically as a steer message when it finishes. `
 						: `The parent is waiting for this result before continuing. `) +
-					`Use subagent_wait or subagent_join only when you need an explicit sync gate.`,
+					`Use this exact id for subagent_wait/subagent_join when you need an explicit sync gate.`,
 			},
 		],
 		details: getStartedSubagentDetails(running),
@@ -2353,7 +2395,7 @@ function launchBackgroundSubagent(
 		cwd: prepared.runtimePaths.effectiveCwd ?? ctx.cwd,
 		detached: true,
 		stdio: ["ignore", "pipe", "pipe"],
-		env: { ...process.env, ...envVars },
+		env: getSubagentChildProcessEnv(invocation, envVars),
 	});
 	child.unref();
 
@@ -2374,6 +2416,14 @@ function launchBackgroundSubagent(
 		sessionFile: prepared.subagentSessionFile,
 		modelContextWindow: resolveModelContextWindow(prepared.effectiveModelRef),
 	};
+	const rememberTail = (current: string | undefined, chunk: Buffer | string) =>
+		`${current ?? ""}${chunk.toString()}`.slice(-4000);
+	child.stdout?.on("data", (chunk) => {
+		running.stdoutTail = rememberTail(running.stdoutTail, chunk);
+	});
+	child.stderr?.on("data", (chunk) => {
+		running.stderrTail = rememberTail(running.stderrTail, chunk);
+	});
 
 	runningSubagents.set(id, running);
 	return running;
@@ -2478,6 +2528,8 @@ function watchBackgroundSubagent(
 					(exitCode !== 0
 						? `Background agent exited with code ${exitCode}`
 						: "Background agent exited without output");
+			} else if (exitCode !== 0 && running.stderrTail?.trim()) {
+				summary = `Background agent exited with code ${exitCode}\n\n${running.stderrTail.trim()}`;
 			}
 			finish({
 				name: running.name,

--- a/src/subagents/index.ts
+++ b/src/subagents/index.ts
@@ -685,10 +685,64 @@ function startWidgetRefresh() {
 }
 
 /**
+ * Split a command override into argv parts. This intentionally supports only
+ * shell-style quoting/escaping, not expansion or operators, because the result
+ * is also used with spawn() for background subagents.
+ */
+function parseCommandWords(command: string): string[] {
+	const words: string[] = [];
+	let current = "";
+	let quote: "'" | '"' | null = null;
+	let escaping = false;
+
+	for (const char of command.trim()) {
+		if (escaping) {
+			current += char;
+			escaping = false;
+			continue;
+		}
+		if (char === "\\" && quote !== "'") {
+			escaping = true;
+			continue;
+		}
+		if ((char === "'" || char === '"') && quote === null) {
+			quote = char;
+			continue;
+		}
+		if (char === quote) {
+			quote = null;
+			continue;
+		}
+		if (/\s/.test(char) && quote === null) {
+			if (current) {
+				words.push(current);
+				current = "";
+			}
+			continue;
+		}
+		current += char;
+	}
+
+	if (escaping) current += "\\";
+	if (quote !== null) throw new Error("PI_SUBAGENT_PI_COMMAND has an unterminated quote");
+	if (current) words.push(current);
+	return words;
+}
+
+/**
  * Resolve the correct pi binary path for spawn(). Handles node, bun,
- * and bundled executables.
+ * bundled executables, and opt-in wrapper commands such as `tia pi`.
  */
 function getPiInvocation(args: string[]): { command: string; args: string[] } {
+	const override = process.env.PI_SUBAGENT_PI_COMMAND?.trim();
+	if (override) {
+		const parts = parseCommandWords(override);
+		if (parts.length === 0) {
+			throw new Error("PI_SUBAGENT_PI_COMMAND did not contain a command");
+		}
+		return { command: parts[0], args: [...parts.slice(1), ...args] };
+	}
+
 	const currentScript = process.argv[1];
 	if (currentScript && existsSync(currentScript)) {
 		return { command: process.execPath, args: [currentScript, ...args] };
@@ -699,6 +753,19 @@ function getPiInvocation(args: string[]): { command: string; args: string[] } {
 		return { command: process.execPath, args };
 	}
 	return { command: "pi", args };
+}
+
+function getPiShellParts(args: string[]): string[] {
+	const invocation = getPiInvocation(args);
+	return [shellEscape(invocation.command), ...invocation.args.map((arg) => shellEscape(arg))];
+}
+
+export function getPiInvocationForTest(args: string[]) {
+	return getPiInvocation(args);
+}
+
+export function getPiShellPartsForTest(args: string[]) {
+	return getPiShellParts(args);
 }
 
 /**
@@ -2482,7 +2549,7 @@ async function launchSubagent(
 		: `${roleBlock}\n\n${modeHint}\n\n${tabTitleInstruction}\n\n${params.task}\n\n${summaryInstruction}`;
 
 	// Build pi command (shell-escaped for sendCommand)
-	const parts: string[] = ["pi", "--session", shellEscape(prepared.subagentSessionFile)];
+	const parts: string[] = getPiShellParts(["--session", prepared.subagentSessionFile]);
 	if (sessionMode !== "standalone") {
 		seedSubagentSessionFile(
 			sessionMode,
@@ -3585,7 +3652,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 				const surface = createSurface(name);
 				await new Promise<void>((resolve) => setTimeout(resolve, getShellReadyDelayMs()));
 
-				const parts = ["pi", "--session", shellEscape(sessionFile)];
+				const parts = getPiShellParts(["--session", sessionFile]);
 				const subagentDonePath = join(
 					dirname(new URL(import.meta.url).pathname),
 					"subagent-done.ts",

--- a/src/subagents/index.ts
+++ b/src/subagents/index.ts
@@ -790,7 +790,9 @@ function getSubagentChildProcessEnv(
 	const env: NodeJS.ProcessEnv = { ...process.env, ...envVars };
 	if (shouldUnsetInheritedTiaEnv(invocation)) {
 		delete env.PI_PACKAGE_DIR;
-		delete env.PI_CODING_AGENT_DIR;
+		if (!envVars.PI_CODING_AGENT_DIR || envVars.PI_CODING_AGENT_DIR === process.env.PI_CODING_AGENT_DIR) {
+			delete env.PI_CODING_AGENT_DIR;
+		}
 	}
 	return env;
 }

--- a/src/subagents/runtime-types.ts
+++ b/src/subagents/runtime-types.ts
@@ -84,6 +84,8 @@ export interface RunningSubagent {
 	completionPromise?: Promise<SubagentResult>;
 	surface?: string;
 	childProcess?: ChildProcess;
+	stderrTail?: string;
+	stdoutTail?: string;
 	startTime: number;
 	sessionFile: string;
 	entries?: number;

--- a/src/subagents/subagent-done.ts
+++ b/src/subagents/subagent-done.ts
@@ -11,9 +11,18 @@ import { shouldAutoExitOnAgentEnd, shouldMarkUserTookOver } from "./auto-exit.ts
 const require = createRequire(import.meta.url);
 
 function isMissingOptionalDependency(error: unknown, id: string): boolean {
-  if (!(error instanceof Error)) return false;
-  const nodeError = error as NodeJS.ErrnoException;
-  return nodeError.code === "MODULE_NOT_FOUND" && error.message.includes(`'${id}'`);
+  const maybeError = error as { code?: unknown; message?: unknown } | null;
+  const message = typeof maybeError?.message === "string" ? maybeError.message : "";
+  const code = maybeError?.code;
+  return (
+    (code === "MODULE_NOT_FOUND" || code == null) &&
+    (message.includes("Cannot find module") || message.includes("Cannot find package")) &&
+    message.includes(id)
+  );
+}
+
+export function isMissingOptionalDependencyForTest(error: unknown, id: string): boolean {
+  return isMissingOptionalDependency(error, id);
 }
 
 function optionalRequire(id: string): unknown | null {

--- a/test/test.ts
+++ b/test/test.ts
@@ -49,6 +49,7 @@ import subagentDoneExtension, {
   getDeniedToolNames,
   installDeniedToolGuards,
   shouldRegisterSubagentDone,
+  isMissingOptionalDependencyForTest,
 } from "../src/subagents/subagent-done.ts";
 import {
   buildPiPromptArgsForTest,
@@ -68,6 +69,7 @@ import {
   getLaunchedSubagentResultForTest,
   getPiInvocationForTest,
   getPiShellPartsForTest,
+  getSubagentChildProcessEnvForTest,
   getStartedSubagentDetailsForTest,
   getSubagentAgentRequirementErrorForTest,
   getSubagentAgentOverrideErrorForTest,
@@ -211,6 +213,7 @@ const TRACKED_ENV_KEYS = [
   "PATH",
   "PI_ARTIFACT_PROJECT_ROOT",
   "PI_CODING_AGENT_DIR",
+  "PI_PACKAGE_DIR",
   "PI_SUBAGENT_MUX",
   "PI_SUBAGENT_PI_COMMAND",
   "PI_SUBAGENT_RENAME_TMUX_SESSION",
@@ -218,6 +221,8 @@ const TRACKED_ENV_KEYS = [
   "SHELL",
   "TMUX",
   "TMUX_PANE",
+  "TIA_ACTIVE",
+  "TIA_COMMAND",
   "WEZTERM_PANE",
   "WEZTERM_UNIX_SOCKET",
   "ZELLIJ",
@@ -1000,6 +1005,10 @@ describe("subagents/index.ts helpers", () => {
 
   it("preserves the default launcher when no subagent command override is set", () => {
     delete process.env.PI_SUBAGENT_PI_COMMAND;
+    delete process.env.TIA_ACTIVE;
+    delete process.env.TIA_COMMAND;
+    delete process.env.PI_PACKAGE_DIR;
+    delete process.env.PI_CODING_AGENT_DIR;
     const invocation = getPiInvocationForTest(["--session", "/tmp/session.jsonl"]);
     assert.equal(invocation.command, process.execPath);
     assert.deepEqual(invocation.args.slice(-2), ["--session", "/tmp/session.jsonl"]);
@@ -1019,12 +1028,68 @@ describe("subagents/index.ts helpers", () => {
     ]);
   });
 
+  it("auto-detects tia parents and launches child pi through tia pi", () => {
+    delete process.env.PI_SUBAGENT_PI_COMMAND;
+    process.env.TIA_ACTIVE = "1";
+    assert.deepEqual(getPiInvocationForTest(["--session", "/tmp/session.jsonl"]), {
+      command: "tia",
+      args: ["pi", "--session", "/tmp/session.jsonl"],
+    });
+  });
+
+  it("auto-detects tia parents from tia package/config env when no marker is available", () => {
+    delete process.env.PI_SUBAGENT_PI_COMMAND;
+    delete process.env.TIA_ACTIVE;
+    delete process.env.TIA_COMMAND;
+    process.env.PI_PACKAGE_DIR = "/Users/example/.local/share/tia/bin";
+    process.env.PI_CODING_AGENT_DIR = "/Users/example/.local/share/tia/pi-agent";
+    assert.deepEqual(getPiInvocationForTest(["--session", "/tmp/session.jsonl"]), {
+      command: "tia",
+      args: ["pi", "--session", "/tmp/session.jsonl"],
+    });
+  });
+
+  it("lets PI_SUBAGENT_PI_COMMAND override automatic tia detection", () => {
+    process.env.PI_SUBAGENT_PI_COMMAND = "custom-pi --flag";
+    process.env.TIA_ACTIVE = "1";
+    assert.deepEqual(getPiInvocationForTest(["--session", "/tmp/session.jsonl"]), {
+      command: "custom-pi",
+      args: ["--flag", "--session", "/tmp/session.jsonl"],
+    });
+  });
+
   it("parses quoted PI_SUBAGENT_PI_COMMAND values", () => {
     process.env.PI_SUBAGENT_PI_COMMAND = "'/opt/tia bin/tia' pi";
     assert.deepEqual(getPiInvocationForTest(["--session", "/tmp/session.jsonl"]), {
       command: "/opt/tia bin/tia",
       args: ["pi", "--session", "/tmp/session.jsonl"],
     });
+  });
+
+  it("does not leak tia package/config env into normal pi child launches", () => {
+    process.env.PI_PACKAGE_DIR = "/tmp/tia/bin";
+    process.env.PI_CODING_AGENT_DIR = "/tmp/tia/pi-agent";
+    const env = getSubagentChildProcessEnvForTest({ command: "pi", args: [] }, { PI_SUBAGENT_NAME: "x" });
+    assert.equal(env.PI_PACKAGE_DIR, undefined);
+    assert.equal(env.PI_CODING_AGENT_DIR, undefined);
+    assert.equal(env.PI_SUBAGENT_NAME, "x");
+  });
+
+  it("preserves non-tia custom PI_CODING_AGENT_DIR for normal pi child launches", () => {
+    delete process.env.PI_PACKAGE_DIR;
+    process.env.PI_CODING_AGENT_DIR = "/tmp/custom-pi-agent";
+    const env = getSubagentChildProcessEnvForTest({ command: "pi", args: [] }, { PI_SUBAGENT_NAME: "x" });
+    assert.equal(env.PI_CODING_AGENT_DIR, "/tmp/custom-pi-agent");
+    assert.equal(env.PI_SUBAGENT_NAME, "x");
+  });
+
+  it("preserves tia package/config env when child launches through tia pi", () => {
+    process.env.PI_PACKAGE_DIR = "/tmp/tia/bin";
+    process.env.PI_CODING_AGENT_DIR = "/tmp/tia/pi-agent";
+    const env = getSubagentChildProcessEnvForTest({ command: "tia", args: ["pi"] }, { PI_SUBAGENT_NAME: "x" });
+    assert.equal(env.PI_PACKAGE_DIR, "/tmp/tia/bin");
+    assert.equal(env.PI_CODING_AGENT_DIR, "/tmp/tia/pi-agent");
+    assert.equal(env.PI_SUBAGENT_NAME, "x");
   });
 
   it("loads global agent defaults from PI_CODING_AGENT_DIR and records cwd base", () => {
@@ -2016,6 +2081,22 @@ describe("subagents/index.ts helpers", () => {
     assert.equal(override, null);
   });
 
+  it("allows redundant launch-time execution values that match named-agent frontmatter", () => {
+    const defs = {
+      path: "/tmp/reviewer.md",
+      mode: "background" as const,
+      blocking: false,
+    };
+
+    assert.equal(
+      getSubagentAgentOverrideErrorForTest(
+        { agent: "reviewer", background: true, blocking: false },
+        defs,
+      ),
+      null,
+    );
+  });
+
   it("allows fork as an explicit launch-time session override", () => {
     const defs = {
       path: "/tmp/reviewer.md",
@@ -2134,7 +2215,7 @@ describe("subagents/index.ts helpers", () => {
     assert.equal(paths.localAgentConfigDir, localAgentDir);
     assert.equal(paths.effectiveAgentConfigDir, localAgentDir);
     assert.equal(paths.targetCwdForSession, target);
-    assert.equal(paths.sessionDir, join(localAgentDir, "sessions", `--tmp-${basename(dir)}-packages-worker--`));
+    assert.equal(paths.sessionDir, join(localAgentDir, "sessions", `--${target.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`));
   });
 
   it("falls back to the global agent dir for child sessions when no local config exists", () => {
@@ -2268,6 +2349,10 @@ describe("subagents/index.ts helpers", () => {
       sessionFile: "/tmp/child-session.jsonl",
     };
 
+    const launched = getLaunchedSubagentResultForTest(running) as any;
+    assert.match(launched.content[0].text, /child-123/);
+    assert.match(launched.content[0].text, /subagent_wait\/subagent_join/);
+
     const started = getStartedSubagentDetailsForTest(running);
     assert.equal(started.status, "started");
     assert.equal(started.mode, "background");
@@ -2305,6 +2390,32 @@ describe("subagents/index.ts helpers", () => {
     assert.equal(cached.parentClosePolicy, "terminate");
     assert.equal(cached.status, "completed");
     assert.equal(getCompletedSubagentResultForTest(running.id)?.deliveredTo, "steer");
+  });
+
+  it("recognizes optional dependency resolution failures from node and bun-style errors", () => {
+    assert.equal(
+      isMissingOptionalDependencyForTest(
+        Object.assign(new Error("Cannot find module '@mariozechner/pi-tui' from '/tmp/ext.ts'"), {
+          code: "MODULE_NOT_FOUND",
+        }),
+        "@mariozechner/pi-tui",
+      ),
+      true,
+    );
+    assert.equal(
+      isMissingOptionalDependencyForTest(
+        { message: "Cannot find module '@mariozechner/pi-tui' from '/tmp/ext.ts'" },
+        "@mariozechner/pi-tui",
+      ),
+      true,
+    );
+    assert.equal(
+      isMissingOptionalDependencyForTest(
+        { message: "Cannot find package 'typebox' imported from /tmp/ext.ts" },
+        "typebox",
+      ),
+      true,
+    );
   });
 
   it("returns an awaited result immediately when launched as blocking", async () => {
@@ -3447,6 +3558,9 @@ describe("mux.ts", () => {
     });
 
     it("selects tmux when it is the available runtime", () => {
+      const dir = createTestDir();
+      writeExecutable(dir, "tmux", "#!/usr/bin/env bash\nexit 0\n");
+      process.env.PATH = `${dir}:${process.env.PATH ?? ""}`;
       process.env.PI_SUBAGENT_MUX = "tmux";
       process.env.TMUX = "test-tmux-socket";
       delete process.env.CMUX_SOCKET_PATH;

--- a/test/test.ts
+++ b/test/test.ts
@@ -66,6 +66,8 @@ import {
   resolveDenyToolsForTest,
   renderSubagentCatalogReminderForTest,
   getLaunchedSubagentResultForTest,
+  getPiInvocationForTest,
+  getPiShellPartsForTest,
   getStartedSubagentDetailsForTest,
   getSubagentAgentRequirementErrorForTest,
   getSubagentAgentOverrideErrorForTest,
@@ -210,6 +212,7 @@ const TRACKED_ENV_KEYS = [
   "PI_ARTIFACT_PROJECT_ROOT",
   "PI_CODING_AGENT_DIR",
   "PI_SUBAGENT_MUX",
+  "PI_SUBAGENT_PI_COMMAND",
   "PI_SUBAGENT_RENAME_TMUX_SESSION",
   "PI_SUBAGENT_RENAME_TMUX_WINDOW",
   "SHELL",
@@ -993,6 +996,35 @@ describe("subagents/index.ts helpers", () => {
   it("uses PI_CODING_AGENT_DIR for the global agent config root", () => {
     process.env.PI_CODING_AGENT_DIR = "/tmp/custom-agent-root";
     assert.equal(getAgentConfigDirForTest(), "/tmp/custom-agent-root");
+  });
+
+  it("preserves the default launcher when no subagent command override is set", () => {
+    delete process.env.PI_SUBAGENT_PI_COMMAND;
+    const invocation = getPiInvocationForTest(["--session", "/tmp/session.jsonl"]);
+    assert.equal(invocation.command, process.execPath);
+    assert.deepEqual(invocation.args.slice(-2), ["--session", "/tmp/session.jsonl"]);
+  });
+
+  it("uses PI_SUBAGENT_PI_COMMAND as an opt-in wrapper for child pi launches", () => {
+    process.env.PI_SUBAGENT_PI_COMMAND = "tia pi";
+    assert.deepEqual(getPiInvocationForTest(["--session", "/tmp/session.jsonl"]), {
+      command: "tia",
+      args: ["pi", "--session", "/tmp/session.jsonl"],
+    });
+    assert.deepEqual(getPiShellPartsForTest(["--session", "/tmp/with space.jsonl"]), [
+      "'tia'",
+      "'pi'",
+      "'--session'",
+      "'/tmp/with space.jsonl'",
+    ]);
+  });
+
+  it("parses quoted PI_SUBAGENT_PI_COMMAND values", () => {
+    process.env.PI_SUBAGENT_PI_COMMAND = "'/opt/tia bin/tia' pi";
+    assert.deepEqual(getPiInvocationForTest(["--session", "/tmp/session.jsonl"]), {
+      command: "/opt/tia bin/tia",
+      args: ["pi", "--session", "/tmp/session.jsonl"],
+    });
   });
 
   it("loads global agent defaults from PI_CODING_AGENT_DIR and records cwd base", () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1083,6 +1083,18 @@ describe("subagents/index.ts helpers", () => {
     assert.equal(env.PI_SUBAGENT_NAME, "x");
   });
 
+  it("preserves explicit child config while stripping inherited tia env for normal pi child launches", () => {
+    process.env.PI_PACKAGE_DIR = "/tmp/tia/bin";
+    process.env.PI_CODING_AGENT_DIR = "/tmp/tia/pi-agent";
+    const env = getSubagentChildProcessEnvForTest(
+      { command: "pi", args: [] },
+      { PI_CODING_AGENT_DIR: "/tmp/project/.pi/agent", PI_SUBAGENT_NAME: "x" },
+    );
+    assert.equal(env.PI_PACKAGE_DIR, undefined);
+    assert.equal(env.PI_CODING_AGENT_DIR, "/tmp/project/.pi/agent");
+    assert.equal(env.PI_SUBAGENT_NAME, "x");
+  });
+
   it("preserves tia package/config env when child launches through tia pi", () => {
     process.env.PI_PACKAGE_DIR = "/tmp/tia/bin";
     process.env.PI_CODING_AGENT_DIR = "/tmp/tia/pi-agent";


### PR DESCRIPTION
## Summary
- Add `PI_SUBAGENT_PI_COMMAND` so subagent child launches can use a wrapper such as `tia pi` when explicitly requested.
- Auto-detect tia parents (`TIA_ACTIVE`, `TIA_COMMAND`, or tia package/config env) and launch child sessions through `tia pi` without requiring an env override.
- Prevent normal `pi` children from inheriting tia package/config env, which caused Node-launched children to load tia Bun-only fast tools and fail on tool calls like `read`.
- Preserve tia env when the child command is `tia pi`, so `tia pi -> tia pi` keeps the fast tool-use stack.
- Allow redundant named-agent `background` / `blocking` values when they match agent frontmatter, expose child ids in launch text, and include child startup stderr in failure summaries.
- Make `subagent-done` optional dependency detection handle Bun/Node package resolution errors including `Cannot find package 'typebox'`.
- Stabilize local tests around tracked env and mux availability.

## Tests
- `npm test` → 149 passed, 0 failed, 4 skipped
- Manual installed-package verification after reloading `tia pi`:
  - background subagents used `bash`, `read`, and `grep`; both completed; no `Bun is not defined`; no not-found/session-file errors.
- Manual local-extension matrix:
  - `tia pi -> tia pi` without `PI_SUBAGENT_PI_COMMAND`: two background subagents used `bash`, `read`, and `grep`; both completed.
  - `pi -> pi` without tia env and without `PI_SUBAGENT_PI_COMMAND`: two background subagents used `bash`, `read`, and `grep`; both completed.
- CMUX interactive launch smoke:
  - interactive cmux subagent launched, read local files, and exited cleanly; surfaced no child-session startup failure.

## Related
- TIA runtime markers and atomic symlink refresh are in https://github.com/dalist1/tia-runtime/pull/1
