### PR TITLE
fix(cmux): isolate interactive subagent surfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "type": "module",
   "scripts": {
-    "test": "node --test test/test.ts test/system-prompt-mode.test.ts test/subagents/sync.test.ts test/subagents/widget.test.ts test/live-test-guard.test.ts",
+    "test": "node --test test/test.ts test/system-prompt-mode.test.ts test/subagents/sync.test.ts test/subagents/widget.test.ts test/subagents/cmux.test.ts test/live-test-guard.test.ts",
     "test:e2e-live": "node scripts/test-e2e-live.mjs",
     "test:e2e-live-blocking": "node scripts/test-e2e-live-blocking.mjs",
     "test:e2e-live-mix-blocking": "node scripts/test-e2e-live-mix-blocking.mjs",

--- a/src/subagents/index.ts
+++ b/src/subagents/index.ts
@@ -27,12 +27,14 @@ import {
 	sendShellCommand,
 	interruptSurface,
 	pollForExit,
+	readScreenAsync,
 	consumeSubagentExitSignal,
 	closeSurface,
 	shellEscape,
 	exitStatusVar,
 	renameCurrentTab,
 	renameWorkspace,
+	getMuxBackend,
 } from "./mux.ts";
 import {
 	getEntries,
@@ -464,6 +466,22 @@ export function getShellReadyDelayMs(): number {
 	const raw = process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS?.trim();
 	const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
 	return Number.isFinite(parsed) && parsed >= 0 ? parsed : 500;
+}
+
+async function waitForInteractivePrompt(surface: string): Promise<void> {
+	const start = Date.now();
+	const timeoutMs = Number.parseInt(
+		process.env.PI_SUBAGENT_PROMPT_READY_TIMEOUT_MS ?? "30000",
+		10,
+	);
+	const deadline = start + (Number.isFinite(timeoutMs) ? timeoutMs : 30000);
+	while (Date.now() < deadline) {
+		try {
+			const screen = await readScreenAsync(surface, 30);
+			if (/^\s*>\s*$/m.test(screen) || screen.includes("No open tasks")) return;
+		} catch {}
+		await new Promise<void>((resolve) => setTimeout(resolve, 500));
+	}
 }
 
 function isSetTabTitleToolEnabled(): boolean {
@@ -3046,7 +3064,11 @@ async function launchSubagent(
 	const command = `${piCommand}; printf '__SUBAGENT_DONE_'${exitStatusVar()}'__\\n' | tee ${shellEscape(doneSentinelFile)}`;
 	sendShellCommand(surface, command);
 	if (injectTaskAfterStart) {
-		await new Promise<void>((resolve) => setTimeout(resolve, Math.max(3000, getShellReadyDelayMs())));
+		if (getMuxBackend() === "cmux") {
+			await waitForInteractivePrompt(surface);
+		} else {
+			await new Promise<void>((resolve) => setTimeout(resolve, Math.max(3000, getShellReadyDelayMs())));
+		}
 		// Dismiss pi's startup/welcome overlay before injecting the task. If the
 		// overlay is active, the first Enter clears it; without this, the task text
 		// can land in the editor but never submit, leaving the foreground child

--- a/src/subagents/index.ts
+++ b/src/subagents/index.ts
@@ -1364,6 +1364,8 @@ function resolveSubagentExtensionSource(source: string, baseDir: string): string
 
 function resolveSubagentExtensions(agentDefs: AgentDefaults | null): string[] | undefined {
 	if (!agentDefs?.extensions) return undefined;
+	const raw = agentDefs.extensions.trim().toLowerCase();
+	if (raw === "none" || raw === "false" || raw === "off" || raw === "[]") return [];
 	const baseDir = agentDefs.cwdBase ?? process.cwd();
 	const resolved = agentDefs.extensions
 		.split(",")

--- a/src/subagents/index.ts
+++ b/src/subagents/index.ts
@@ -3371,7 +3371,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 	function applySubagentSessionTitle(ctx: ExtensionContext) {
 		if (areSubagentSessionTitlesDisabled()) return;
 		const title = process.env.PI_SUBAGENT_SESSION_TITLE?.trim();
-		if (!title || ctx.sessionManager.getSessionName() === title) return;
+		if (!title || ctx.sessionManager.getSessionName?.() === title) return;
 		pi.setSessionName(title);
 	}
 

--- a/src/subagents/mux.ts
+++ b/src/subagents/mux.ts
@@ -177,15 +177,13 @@ let cmuxSubagentPane: string | null = null;
 export function createSurface(name: string): string {
   const backend = getMuxBackend();
 
-  if (backend === "cmux" && cmuxSubagentPane) {
-    try {
-      const tree = execSync(`cmux tree`, { encoding: "utf8" });
-      if (tree.includes(cmuxSubagentPane)) {
-        return createSurfaceInPane(name, cmuxSubagentPane);
-      }
-    } catch {}
-    cmuxSubagentPane = null;
-  }
+  // Do not reuse a single cmux pane for multiple interactive subagents.
+  // cmux surfaces created with `new-surface --pane <pane>` can exist, but in
+  // practice concurrent/sequential interactive child launches can leave later
+  // prompts in a non-visible/non-focused surface and polling then fails with
+  // "Failed to read subagent surface while polling for exit". Give every
+  // interactive child its own split/surface so input injection and read-screen
+  // target an independently visible terminal.
 
   const surface = createSurfaceSplit(
     name,
@@ -210,7 +208,7 @@ export function createSurface(name: string): string {
 }
 
 function createSurfaceInPane(name: string, pane: string): string {
-  const out = execSync(`cmux new-surface --pane ${shellEscape(pane)}`, {
+  const out = execSync(`cmux new-surface --pane ${shellEscape(pane)} --focus true`, {
     encoding: "utf8",
   }).trim();
   const match = out.match(/surface:\d+/);
@@ -233,7 +231,7 @@ export function createSurfaceSplit(
 
   if (backend === "cmux") {
     const surfaceArg = fromSurface ? ` --surface ${shellEscape(fromSurface)}` : "";
-    const out = execSync(`cmux new-split ${direction}${surfaceArg}`, {
+    const out = execSync(`cmux new-split ${direction}${surfaceArg} --focus true`, {
       encoding: "utf8",
     }).trim();
     const match = out.match(/surface:\d+/);

--- a/test/subagents/cmux.test.ts
+++ b/test/subagents/cmux.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { createSurface, createSurfaceSplit } from "../../src/subagents/mux.ts";
+
+const ORIGINAL_ENV = {
+  PATH: process.env.PATH,
+  PI_SUBAGENT_MUX: process.env.PI_SUBAGENT_MUX,
+  CMUX_SOCKET_PATH: process.env.CMUX_SOCKET_PATH,
+};
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value == null) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function installFakeCmux(): { dir: string; log: string } {
+  const dir = mkdtempSync(join(tmpdir(), "pi-subagents-cmux-test-"));
+  const log = join(dir, "cmux.log");
+  const bin = join(dir, "cmux");
+  writeFileSync(
+    bin,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const log = process.env.FAKE_CMUX_LOG;
+const args = process.argv.slice(2);
+if (log) fs.appendFileSync(log, JSON.stringify(args) + "\\n");
+const cmd = args[0];
+if (cmd === "new-split") {
+  console.log("OK surface:101 workspace:1");
+} else if (cmd === "new-surface") {
+  console.log("OK surface:102 pane:9 workspace:1");
+} else if (cmd === "rename-tab") {
+  console.log("OK rename-tab");
+} else if (cmd === "identify") {
+  console.log(JSON.stringify({ caller: { pane_ref: "pane:9" } }));
+} else if (cmd === "tree") {
+  console.log("workspace:1\\n  pane:9");
+} else {
+  console.error("unexpected cmux command", args.join(" "));
+  process.exit(2);
+}
+`,
+  );
+  chmodSync(bin, 0o755);
+  process.env.PATH = `${dir}:${ORIGINAL_ENV.PATH ?? ""}`;
+  process.env.PI_SUBAGENT_MUX = "cmux";
+  process.env.CMUX_SOCKET_PATH = join(dir, "cmux.sock");
+  process.env.FAKE_CMUX_LOG = log;
+  return { dir, log };
+}
+
+function readLog(log: string): string[][] {
+  return readFileSync(log, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+describe("cmux surface creation", () => {
+  it("focuses new cmux splits so terminal-backed read-screen works", () => {
+    const { dir, log } = installFakeCmux();
+    try {
+      assert.equal(createSurfaceSplit("Focused Split", "right"), "surface:101");
+      const calls = readLog(log);
+      assert.ok(
+        calls.some((args) =>
+          args[0] === "new-split" &&
+          args.includes("right") &&
+          args.includes("--focus") &&
+          args.includes("true"),
+        ),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates separate focused cmux splits for separate interactive subagents", () => {
+    const { dir, log } = installFakeCmux();
+    try {
+      assert.equal(createSurface("First"), "surface:101");
+      assert.equal(createSurface("Second"), "surface:101");
+      const calls = readLog(log);
+      const splitCalls = calls.filter((args) => args[0] === "new-split");
+      assert.equal(splitCalls.length, 2);
+      assert.ok(
+        splitCalls.every((args) =>
+          args.includes("right") &&
+          args.includes("--focus") &&
+          args.includes("true"),
+        ),
+      );
+      assert.equal(calls.some((args) => args[0] === "new-surface"), false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/test.ts
+++ b/test/test.ts
@@ -3990,8 +3990,8 @@ esac
       closeSurface(secondSurface);
 
       const log = readFileSync(logFile, "utf8");
-      assert.match(log, /new-split/);
-      assert.match(log, /new-surface/);
+      assert.match(log, /new-split right --focus true/);
+      assert.doesNotMatch(log, /new-surface/);
       assert.match(log, /rename-tab/);
       assert.match(log, /workspace-action/);
       assert.match(log, /send/);

--- a/test/test.ts
+++ b/test/test.ts
@@ -1215,6 +1215,26 @@ describe("subagents/index.ts helpers", () => {
     );
   });
 
+  it("allows extensions none to launch child with only mandatory internal extension", () => {
+    const dir = createTestDir();
+    const configDir = join(dir, "agent-root");
+    const agentsDir = join(configDir, "agents");
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(
+      join(agentsDir, "tester.md"),
+      `---\nname: tester\nextensions: none\nskills: research, exa\n---\n\nYou are the tester.`,
+    );
+    process.env.PI_CODING_AGENT_DIR = configDir;
+
+    const defs = loadAgentDefaults("tester");
+    assert.equal(defs?.extensions, "none");
+    assert.deepEqual(resolveSubagentExtensionsForTest(defs), []);
+    assert.deepEqual(
+      getExtensionLaunchArgsForTest(resolveSubagentExtensionsForTest(defs), "/tmp/subagent-done.ts"),
+      ["--no-extensions", "-e", "/tmp/subagent-done.ts"],
+    );
+  });
+
   it("reads skills from skills frontmatter only", () => {
     const dir = createTestDir();
     const configDir = join(dir, "agent-root");

--- a/test/test.ts
+++ b/test/test.ts
@@ -252,6 +252,21 @@ const ORIGINAL_ENV = Object.fromEntries(
   TRACKED_ENV_KEYS.map((key) => [key, process.env[key]]),
 ) as Record<(typeof TRACKED_ENV_KEYS)[number], string | undefined>;
 
+const ISOLATED_SUBAGENT_ENV_KEYS = [
+  "PI_DENY_TOOLS",
+  "PI_SUBAGENT_AUTO_EXIT",
+  "PI_SUBAGENT_DISABLE_AMBIENT_AWARENESS",
+  "PI_SUBAGENT_PARENT_SESSION",
+  "PI_SUBAGENT_SESSION",
+  "PI_SUBAGENT_SESSION_TITLE",
+] as const;
+
+function clearIsolatedSubagentEnv(): void {
+  for (const key of ISOLATED_SUBAGENT_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
 function restoreTrackedEnv(): void {
   for (const key of TRACKED_ENV_KEYS) {
     const value = ORIGINAL_ENV[key];
@@ -262,6 +277,10 @@ function restoreTrackedEnv(): void {
     }
   }
 }
+
+beforeEach(() => {
+  clearIsolatedSubagentEnv();
+});
 
 afterEach(() => {
   restoreTrackedEnv();


### PR DESCRIPTION
## Summary
- avoid reusing a cached cmux pane for multiple interactive subagents; each child now gets its own focused split/surface
- wait for the cmux child prompt to become visible before injecting the task, avoiding lost prompts for slower interactive agents
- keep non-cmux multiplexers on the existing fixed-delay behavior
- add/update fake cmux coverage for focused splits and no new-surface pane reuse

## Verification
- `node --test test/test.ts test/system-prompt-mode.test.ts test/subagents/sync.test.ts test/subagents/widget.test.ts test/subagents/cmux.test.ts test/live-test-guard.test.ts`
- live local TIA/cmux smoke: 3 parallel interactive agents (planner/spec/researcher) all received prompts automatically with no manual Enter

## Notes
The old cmux pane reuse path could create later child sessions as non-selected surfaces inside the first child pane. In practice those sessions could appear to exist but never receive visible prompt input, then fail while polling the surface.