### PR TITLE
fix: global agents use parentCwd for local .pi/agent detection

### DIFF
--- a/src/launch/runtime-paths.ts
+++ b/src/launch/runtime-paths.ts
@@ -51,7 +51,11 @@ export function resolveSubagentRuntimePaths(
 	const rawCwd = params.cwd ?? agentDefs?.cwd ?? null;
 	const cwdBase = params.cwd ? parentCwd : (agentDefs?.cwdBase ?? parentCwd);
 	const effectiveCwd = rawCwd ? resolveSubagentCwd(rawCwd, cwdBase) : null;
-	const localAgentConfigDir = getEnvAgentConfigDir(agentDefs?.env) ?? resolveSubagentConfigDir(rawCwd, cwdBase);
+	// Use parentCwd for local .pi/agent detection when no explicit cwd is set.
+	// Global agents have cwdBase=~/.pi/agent (config dir); using it for detection
+	// can falsely match a nested .pi/agent/ inside it, picking up the wrong config.
+	const configCheckBase = rawCwd ? cwdBase : parentCwd;
+	const localAgentConfigDir = getEnvAgentConfigDir(agentDefs?.env) ?? resolveSubagentConfigDir(rawCwd, configCheckBase);
 	const effectiveAgentConfigDir = localAgentConfigDir ?? getAgentConfigDir();
 	const targetCwdForSession = effectiveCwd ?? parentCwd;
 	return {

--- a/test/launch/env-frontmatter.test.ts
+++ b/test/launch/env-frontmatter.test.ts
@@ -81,6 +81,29 @@ describe("env frontmatter field", () => {
 		assert.equal(paths.sessionDir, join(childConfigDir, "sessions", `--${dir.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`));
 	});
 
+	it("global agent: does not pick up nested .pi/agent/ inside its own cwdBase", () => {
+		const dir = createTestDir();
+		const configDir = join(dir, "global-config");
+		// Simulate the stale nested dir: ~/.pi/agent/.pi/agent/
+		const nestedDir = join(configDir, ".pi", "agent");
+		mkdirSync(nestedDir, { recursive: true });
+		const parentCwd = join(dir, "project");
+		mkdirSync(parentCwd, { recursive: true });
+		const parentSessionDir = join(dir, "parent-sessions");
+
+		// Global agent: cwdBase = configDir, no explicit cwd
+		const paths = resolveSubagentRuntimePathsForTest(
+			{},
+			{ cwdBase: configDir },
+			parentCwd,
+			parentSessionDir,
+		);
+
+		// Should NOT resolve to the nested dir inside configDir
+		assert.equal(paths.localAgentConfigDir, null);
+		assert.equal(paths.sessionDir, parentSessionDir);
+	});
+
 	it("returns empty env record when no env field is set", () => {
 		const env = getBaseSubagentEnvVarsForTest(null);
 		assert.equal(env["FOO"], undefined);


### PR DESCRIPTION
## Problem

Global agent definitions (e.g. `~/.pi/agent/agents/email.md`) get `cwdBase = ~/.pi/agent` (the config dir). `resolveSubagentConfigDir` was called with that as `baseCwd`, so it checked whether `~/.pi/agent/.pi/agent/` exists.

If that nested directory exists (stale sessions, accidental creation), the child agent silently receives the wrong `PI_CODING_AGENT_DIR` — pointing inside the config dir instead of the real project config. Result: missing `mcp.json`, 0 MCP servers, extensions not loading.

The root cause is a semantic mismatch: the agent definition's own home directory (`cwdBase`) should not be used to detect whether a *project-local* `.pi/agent/` is present.

## Fix

When `rawCwd` is null (no explicit `cwd:` on the agent), use `parentCwd` (the actual working directory of the parent session) for local config detection instead of `agentDefs.cwdBase`:

```ts
const configCheckBase = rawCwd ? cwdBase : parentCwd;
const localAgentConfigDir = getEnvAgentConfigDir(agentDefs?.env)
  ?? resolveSubagentConfigDir(rawCwd, configCheckBase);
```

When `rawCwd` *is* set, `cwdBase` is still used for relative resolution — existing behaviour preserved.

## Test

Added a regression test in `test/launch/env-frontmatter.test.ts`: creates a nested `.pi/agent/` inside a simulated global config dir, asserts `localAgentConfigDir` is `null` and session falls back to `parentSessionDir`.