### PR TITLE
fix(zellij): resolve renamed session at startup

### DIFF
--- a/src/mux.ts
+++ b/src/mux.ts
@@ -1,3 +1,5 @@
+// Re-export Zellij discovery lifecycle hooks here so extension wiring does not
+// depend on the private module layout of the mux implementation.
 export {
 	exitStatusVar,
 	getMuxBackend,

--- a/src/mux.ts
+++ b/src/mux.ts
@@ -1,6 +1,8 @@
 export {
 	exitStatusVar,
 	getMuxBackend,
+	getZellijRuntimeError,
+	initializeZellijRuntimeContext,
 	isCmuxAvailable,
 	isFishShell,
 	isHerdrAvailable,
@@ -8,6 +10,7 @@ export {
 	isTmuxAvailable,
 	isZellijAvailable,
 	muxSetupHint,
+	resetZellijRuntimeContext,
 	shellEscape,
 } from "./mux/core.ts";
 export {

--- a/src/mux/core.ts
+++ b/src/mux/core.ts
@@ -8,11 +8,16 @@ export const execFileAsync = promisify(execFile);
 
 export type MuxBackend = "cmux" | "tmux" | "zellij" | "wezterm" | "herdr";
 
+// Zellij does not update an existing process environment after a session rename.
+// Keep the live session identity discovered at Pi startup instead of trusting the
+// inherited ZELLIJ_SESSION_NAME for later subagent actions.
 export interface ZellijRuntimeContext {
 	sessionName: string;
 	parentPaneId: number;
 }
 
+// Pane IDs repeat between Zellij sessions, so discovery needs pane state, cwd,
+// and attached-client information to identify the session without guessing.
 export interface ZellijSessionSnapshot {
 	name: string;
 	panes: Array<{
@@ -27,6 +32,8 @@ export interface ZellijSessionSnapshot {
 let zellijRuntimeContext: ZellijRuntimeContext | null = null;
 let zellijRuntimeError: string | null = null;
 
+// Client focus is only a tie-breaker: an interactive child Pi often runs in a
+// non-focused pane while the single attached client remains on the parent pane.
 function parseZellijClientPaneIds(output: string): number[] {
 	return output
 		.split("\n")
@@ -48,6 +55,13 @@ function samePath(left: string | undefined, right: string): boolean {
 	}
 }
 
+/**
+ * Resolves the current Zellij session from live pane snapshots.
+ *
+ * A unique pane ID is sufficient. Reused pane IDs are narrowed by cwd, then by
+ * attached-client focus. Remaining ambiguity fails closed so commands cannot be
+ * routed into an unrelated session.
+ */
 export function resolveZellijRuntimeContextFromSnapshots(
 	parentPaneId: number,
 	cwd: string,
@@ -63,6 +77,8 @@ export function resolveZellijRuntimeContextFromSnapshots(
 		return { sessionName: candidates[0].name, parentPaneId };
 	}
 
+	// Session renames leave the old name in process.env, but the pane cwd remains
+	// tied to the actual session and disambiguates common same-ID collisions.
 	const cwdMatches = candidates.filter((snapshot) =>
 		snapshot.panes.some(
 			(pane) =>
@@ -76,6 +92,8 @@ export function resolveZellijRuntimeContextFromSnapshots(
 		return { sessionName: cwdMatches[0].name, parentPaneId };
 	}
 
+	// The focused client identifies the parent Pi pane when cwd alone is not
+	// unique. Child panes do not depend on this fallback.
 	const clientMatches = candidates.filter((snapshot) =>
 		snapshot.clientPaneIds.includes(parentPaneId),
 	);
@@ -111,6 +129,8 @@ function discoverZellijRuntimeContext(cwd: string): ZellijRuntimeContext {
 	const snapshots: ZellijSessionSnapshot[] = [];
 	for (const name of sessions) {
 		try {
+			// Every probe names its target explicitly. Using an implicit action here
+			// would reproduce the stale-environment bug discovery is meant to fix.
 			const panes = JSON.parse(
 				execFileSync(
 					"zellij",
@@ -135,6 +155,9 @@ function discoverZellijRuntimeContext(cwd: string): ZellijRuntimeContext {
 	return resolveZellijRuntimeContextFromSnapshots(parentPaneId, cwd, snapshots);
 }
 
+// session_start performs discovery once per Pi session. Cache failures as well
+// as successes so later launches return the original diagnostic without falling
+// back to the stale inherited session name.
 export function initializeZellijRuntimeContext(
 	cwd: string,
 ): ZellijRuntimeContext | null {
@@ -154,6 +177,8 @@ export function resetZellijRuntimeContext(): void {
 	zellijRuntimeError = null;
 }
 
+// Fake Zellij tests do not have a real session server to discover. Seeding the
+// same runtime contract keeps those tests focused on placement and I/O behavior.
 export function setZellijRuntimeContextForTests(
 	context: ZellijRuntimeContext,
 ): void {
@@ -167,6 +192,8 @@ export function getZellijRuntimeError(): string | null {
 
 export function requireZellijRuntimeContext(): ZellijRuntimeContext {
 	if (zellijRuntimeContext) return zellijRuntimeContext;
+	// Failing here is safer than silently sending pane operations to whichever
+	// session the inherited environment happens to name.
 	throw new Error(
 		zellijRuntimeError ??
 			"Zellij runtime was not initialized during Pi session startup.",
@@ -301,6 +328,8 @@ function zellijEnv(
 	sessionName: string,
 	surface?: string,
 ): NodeJS.ProcessEnv {
+	// Child commands may inspect ZELLIJ_SESSION_NAME themselves. Override the stale
+	// inherited value so command arguments and environment describe one session.
 	const env: NodeJS.ProcessEnv = {
 		...process.env,
 		ZELLIJ_SESSION_NAME: sessionName,
@@ -331,6 +360,8 @@ export function getZellijActionInvocation(
 ): { args: string[]; env: NodeJS.ProcessEnv } {
 	const runtime = requireZellijRuntimeContext();
 	return {
+		// Explicit targeting avoids Zellij's implicit lookup through the immutable
+		// environment inherited before a session was renamed.
 		args: [
 			"--session",
 			runtime.sessionName,

--- a/src/mux/core.ts
+++ b/src/mux/core.ts
@@ -1,5 +1,5 @@
 import { execFile, execFileSync } from "node:child_process";
-import { basename } from "node:path";
+import { basename, resolve as resolvePath } from "node:path";
 import { promisify } from "node:util";
 import { isHerdrRuntimeAvailable } from "./herdr.ts";
 import { defaultMuxRuntimeProbe } from "./runtime-probe.ts";
@@ -7,6 +7,171 @@ import { defaultMuxRuntimeProbe } from "./runtime-probe.ts";
 export const execFileAsync = promisify(execFile);
 
 export type MuxBackend = "cmux" | "tmux" | "zellij" | "wezterm" | "herdr";
+
+export interface ZellijRuntimeContext {
+	sessionName: string;
+	parentPaneId: number;
+}
+
+export interface ZellijSessionSnapshot {
+	name: string;
+	panes: Array<{
+		id: number;
+		is_plugin?: boolean;
+		exited?: boolean;
+		pane_cwd?: string;
+	}>;
+	clientPaneIds: number[];
+}
+
+let zellijRuntimeContext: ZellijRuntimeContext | null = null;
+let zellijRuntimeError: string | null = null;
+
+function parseZellijClientPaneIds(output: string): number[] {
+	return output
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.slice(1)
+		.map((line) => line.split(/\s+/)[1])
+		.map((pane) => pane?.match(/(?:terminal_)?(\d+)/)?.[1])
+		.filter((paneId): paneId is string => !!paneId)
+		.map(Number);
+}
+
+function samePath(left: string | undefined, right: string): boolean {
+	if (!left) return false;
+	try {
+		return resolvePath(left) === resolvePath(right);
+	} catch {
+		return left === right;
+	}
+}
+
+export function resolveZellijRuntimeContextFromSnapshots(
+	parentPaneId: number,
+	cwd: string,
+	snapshots: ZellijSessionSnapshot[],
+): ZellijRuntimeContext {
+	const candidates = snapshots.filter((snapshot) =>
+		snapshot.panes.some(
+			(pane) =>
+				pane.id === parentPaneId && !pane.is_plugin && !pane.exited,
+		),
+	);
+	if (candidates.length === 1) {
+		return { sessionName: candidates[0].name, parentPaneId };
+	}
+
+	const cwdMatches = candidates.filter((snapshot) =>
+		snapshot.panes.some(
+			(pane) =>
+				pane.id === parentPaneId &&
+				!pane.is_plugin &&
+				!pane.exited &&
+				samePath(pane.pane_cwd, cwd),
+		),
+	);
+	if (cwdMatches.length === 1) {
+		return { sessionName: cwdMatches[0].name, parentPaneId };
+	}
+
+	const clientMatches = candidates.filter((snapshot) =>
+		snapshot.clientPaneIds.includes(parentPaneId),
+	);
+	if (clientMatches.length === 1) {
+		return { sessionName: clientMatches[0].name, parentPaneId };
+	}
+
+	if (candidates.length === 0) {
+		throw new Error(
+			`Could not discover the Zellij session containing pane ${parentPaneId}.`,
+		);
+	}
+	throw new Error(
+		`Zellij pane ${parentPaneId} matches multiple sessions: ${candidates
+			.map((candidate) => candidate.name)
+			.join(", ")}.`,
+	);
+}
+
+function discoverZellijRuntimeContext(cwd: string): ZellijRuntimeContext {
+	const parentPaneId = Number(process.env.ZELLIJ_PANE_ID);
+	if (!Number.isInteger(parentPaneId)) {
+		throw new Error("ZELLIJ_PANE_ID is missing or invalid.");
+	}
+	const sessions = execFileSync(
+		"zellij",
+		["list-sessions", "--short", "--no-formatting"],
+		{ encoding: "utf8" },
+	)
+		.split("\n")
+		.map((session) => session.trim())
+		.filter(Boolean);
+	const snapshots: ZellijSessionSnapshot[] = [];
+	for (const name of sessions) {
+		try {
+			const panes = JSON.parse(
+				execFileSync(
+					"zellij",
+					["--session", name, "action", "list-panes", "--json", "--state"],
+					{ encoding: "utf8" },
+				),
+			);
+			if (!Array.isArray(panes)) continue;
+			let clientPaneIds: number[] = [];
+			try {
+				clientPaneIds = parseZellijClientPaneIds(
+					execFileSync(
+						"zellij",
+						["--session", name, "action", "list-clients"],
+						{ encoding: "utf8" },
+					),
+				);
+			} catch {}
+			snapshots.push({ name, panes, clientPaneIds });
+		} catch {}
+	}
+	return resolveZellijRuntimeContextFromSnapshots(parentPaneId, cwd, snapshots);
+}
+
+export function initializeZellijRuntimeContext(
+	cwd: string,
+): ZellijRuntimeContext | null {
+	try {
+		zellijRuntimeContext = discoverZellijRuntimeContext(cwd);
+		zellijRuntimeError = null;
+		return zellijRuntimeContext;
+	} catch (error) {
+		zellijRuntimeContext = null;
+		zellijRuntimeError = error instanceof Error ? error.message : String(error);
+		return null;
+	}
+}
+
+export function resetZellijRuntimeContext(): void {
+	zellijRuntimeContext = null;
+	zellijRuntimeError = null;
+}
+
+export function setZellijRuntimeContextForTests(
+	context: ZellijRuntimeContext,
+): void {
+	zellijRuntimeContext = context;
+	zellijRuntimeError = null;
+}
+
+export function getZellijRuntimeError(): string | null {
+	return zellijRuntimeError;
+}
+
+export function requireZellijRuntimeContext(): ZellijRuntimeContext {
+	if (zellijRuntimeContext) return zellijRuntimeContext;
+	throw new Error(
+		zellijRuntimeError ??
+			"Zellij runtime was not initialized during Pi session startup.",
+	);
+}
 
 function hasCommand(command: string): boolean {
 	return defaultMuxRuntimeProbe.hasCommand(command);
@@ -132,8 +297,14 @@ export function zellijPaneId(surface: string): string {
 	return surface.startsWith("pane:") ? surface.slice("pane:".length) : surface;
 }
 
-function zellijEnv(surface?: string): NodeJS.ProcessEnv {
-	const env: NodeJS.ProcessEnv = { ...process.env };
+function zellijEnv(
+	sessionName: string,
+	surface?: string,
+): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = {
+		...process.env,
+		ZELLIJ_SESSION_NAME: sessionName,
+	};
 	if (surface) env.ZELLIJ_PANE_ID = zellijPaneId(surface);
 	return env;
 }
@@ -154,13 +325,30 @@ function zellijActionArgs(args: string[], surface?: string): string[] {
 	return [action, "--pane-id", zellijPaneId(surface), ...args.slice(1)];
 }
 
+export function getZellijActionInvocation(
+	args: string[],
+	surface?: string,
+): { args: string[]; env: NodeJS.ProcessEnv } {
+	const runtime = requireZellijRuntimeContext();
+	return {
+		args: [
+			"--session",
+			runtime.sessionName,
+			"action",
+			...zellijActionArgs(args, surface),
+		],
+		env: zellijEnv(runtime.sessionName, surface),
+	};
+}
+
 export function zellijActionSync(args: string[], surface?: string): string {
+	const invocation = getZellijActionInvocation(args, surface);
 	return execFileSync(
 		"zellij",
-		["action", ...zellijActionArgs(args, surface)],
+		invocation.args,
 		{
 			encoding: "utf8",
-			env: zellijEnv(surface),
+			env: invocation.env,
 		},
 	);
 }

--- a/src/mux/io.ts
+++ b/src/mux/io.ts
@@ -122,6 +122,8 @@ export function readScreen(surface: string, lines = 50): string {
 		return tailLines(raw, lines);
 	}
 	if (backend === "zellij") {
+		// Use the shared action wrapper so polling reads the resolved live session,
+		// not a stale ZELLIJ_SESSION_NAME inherited before a rename.
 		const raw = zellijActionSync(["dump-screen"], surface);
 		return tailLines(raw, lines);
 	}
@@ -156,6 +158,8 @@ export async function readScreenAsync(surface: string, lines = 50): Promise<stri
 		return tailLines(stdout, lines);
 	}
 	if (backend === "zellij") {
+		// Async polling must carry the same explicit session and corrected env as
+		// synchronous actions; bypassing the wrapper would split command routing.
 		const invocation = getZellijActionInvocation(["dump-screen"], surface);
 		const { stdout } = await execFileAsync(
 			"zellij",

--- a/src/mux/io.ts
+++ b/src/mux/io.ts
@@ -4,12 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	execFileAsync,
+	getZellijActionInvocation,
 	isFishShell,
 	requireMuxBackend,
 	shellEscape,
 	tailLines,
 	zellijActionSync,
-	zellijPaneId,
 } from "./core.ts";
 import {
 	closeHerdrPane,
@@ -122,11 +122,7 @@ export function readScreen(surface: string, lines = 50): string {
 		return tailLines(raw, lines);
 	}
 	if (backend === "zellij") {
-		const raw = execFileSync(
-			"zellij",
-			["action", "dump-screen", "--pane-id", zellijPaneId(surface)],
-			{ encoding: "utf8" },
-		);
+		const raw = zellijActionSync(["dump-screen"], surface);
 		return tailLines(raw, lines);
 	}
 	if (backend === "herdr") return readHerdrPaneScreen(surface, lines);
@@ -160,10 +156,11 @@ export async function readScreenAsync(surface: string, lines = 50): Promise<stri
 		return tailLines(stdout, lines);
 	}
 	if (backend === "zellij") {
+		const invocation = getZellijActionInvocation(["dump-screen"], surface);
 		const { stdout } = await execFileAsync(
 			"zellij",
-			["action", "dump-screen", "--pane-id", zellijPaneId(surface)],
-			{ encoding: "utf8" },
+			invocation.args,
+			{ encoding: "utf8", env: invocation.env },
 		);
 		return tailLines(stdout, lines);
 	}

--- a/src/mux/zellij-anchor-state.ts
+++ b/src/mux/zellij-anchor-state.ts
@@ -26,6 +26,8 @@ interface ZellijPlacementStateFile {
 }
 
 function zellijSessionSlug(): string {
+	// Placement groups must follow the discovered live session. Using the inherited
+	// name would mix state between the renamed session and its former name.
 	return requireZellijRuntimeContext().sessionName.replace(
 		/[^A-Za-z0-9_.-]/g,
 		"_",

--- a/src/mux/zellij-anchor-state.ts
+++ b/src/mux/zellij-anchor-state.ts
@@ -8,6 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { requireZellijRuntimeContext } from "./core.ts";
 import type { ZellijPlacementPolicy } from "./zellij-policy.ts";
 
 interface ZellijPlacementGroupState {
@@ -25,9 +26,10 @@ interface ZellijPlacementStateFile {
 }
 
 function zellijSessionSlug(): string {
-	return (
-		process.env.ZELLIJ_SESSION_NAME ?? process.env.ZELLIJ ?? "default"
-	).replace(/[^A-Za-z0-9_.-]/g, "_");
+	return requireZellijRuntimeContext().sessionName.replace(
+		/[^A-Za-z0-9_.-]/g,
+		"_",
+	);
 }
 
 function zellijPlacementStatePath(): string {

--- a/src/mux/zellij-placement.ts
+++ b/src/mux/zellij-placement.ts
@@ -7,7 +7,10 @@ import {
 	writeZellijPlacementState,
 	zellijPlacementGroupId,
 } from "./zellij-anchor-state.ts";
-import { zellijActionSync } from "./core.ts";
+import {
+	requireZellijRuntimeContext,
+	zellijActionSync,
+} from "./core.ts";
 
 import {
 	DEFAULT_ZELLIJ_SUBAGENT_MIN_COLUMNS,
@@ -255,9 +258,10 @@ function sleepSync(milliseconds: number): void {
 }
 
 function zellijSessionSlug(): string {
-	return (
-		process.env.ZELLIJ_SESSION_NAME ?? process.env.ZELLIJ ?? "default"
-	).replace(/[^A-Za-z0-9_.-]/g, "_");
+	return requireZellijRuntimeContext().sessionName.replace(
+		/[^A-Za-z0-9_.-]/g,
+		"_",
+	);
 }
 
 function zellijSurfaceLockPath(): string {
@@ -294,7 +298,7 @@ function withZellijSurfaceLock<T>(callback: () => T): T {
 }
 
 function defaultPlacementContext(): ZellijPlacementContext {
-	const parentPaneId = Number(process.env.ZELLIJ_PANE_ID);
+	const parentPaneId = requireZellijRuntimeContext().parentPaneId;
 	return {
 		groupKey:
 			process.env.PI_SUBAGENT_SESSION ??
@@ -313,7 +317,7 @@ function createZellijSurfaceUnlocked(
 ): string {
 	const context = providedContext ?? defaultPlacementContext();
 	const parentPaneId =
-		context.parentPaneId ?? Number(process.env.ZELLIJ_PANE_ID);
+		context.parentPaneId ?? requireZellijRuntimeContext().parentPaneId;
 	const policy =
 		context.policy ??
 		resolveZellijPlacementPolicy(process.env.PI_SUBAGENT_ZELLIJ_PLACEMENT);

--- a/src/mux/zellij-placement.ts
+++ b/src/mux/zellij-placement.ts
@@ -258,6 +258,8 @@ function sleepSync(milliseconds: number): void {
 }
 
 function zellijSessionSlug(): string {
+	// Serialize pane creation per live session. A stale environment-derived slug
+	// would lock the wrong session and allow concurrent placement races.
 	return requireZellijRuntimeContext().sessionName.replace(
 		/[^A-Za-z0-9_.-]/g,
 		"_",
@@ -298,6 +300,8 @@ function withZellijSurfaceLock<T>(callback: () => T): T {
 }
 
 function defaultPlacementContext(): ZellijPlacementContext {
+	// The startup resolver owns pane identity as well as session identity, keeping
+	// placement inputs from two different Zellij sessions from being combined.
 	const parentPaneId = requireZellijRuntimeContext().parentPaneId;
 	return {
 		groupKey:
@@ -316,6 +320,8 @@ function createZellijSurfaceUnlocked(
 	providedContext?: ZellijPlacementContext,
 ): string {
 	const context = providedContext ?? defaultPlacementContext();
+	// Explicit callers may provide an anchor, but the discovered parent remains the
+	// only safe fallback when inherited Zellij environment has gone stale.
 	const parentPaneId =
 		context.parentPaneId ?? requireZellijRuntimeContext().parentPaneId;
 	const policy =

--- a/src/subagents.ts
+++ b/src/subagents.ts
@@ -166,6 +166,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 	pi.on("session_start", (event, ctx) => {
 		latestContext = ctx;
 		resetSubagentBatchStopRequest();
+		// Resolve Zellij identity before any tool can create a pane. Existing shells
+		// can retain an old session name after rename, so launch-time env is not safe.
 		if (getMuxBackend() === "zellij") {
 			const runtime = initializeZellijRuntimeContext(ctx.cwd);
 			traceSubagentLaunch("zellij.runtime", {
@@ -174,6 +176,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 				error: runtime ? undefined : getZellijRuntimeError(),
 			});
 		} else {
+			// Module state survives extension reloads; clear Zellij data when another
+			// backend owns this Pi session so it cannot leak into later actions.
 			resetZellijRuntimeContext();
 		}
 		applySubagentLineage(ctx);

--- a/src/subagents.ts
+++ b/src/subagents.ts
@@ -27,7 +27,14 @@ import {
 	resolveTaskSessionMode as resolveTaskSessionModeFromSessionFiles,
 	type SubagentSessionMode,
 } from "./session/session-files.ts";
-import { isMuxAvailable, muxSetupHint } from "./mux.ts";
+import {
+	getMuxBackend,
+	getZellijRuntimeError,
+	initializeZellijRuntimeContext,
+	isMuxAvailable,
+	muxSetupHint,
+	resetZellijRuntimeContext,
+} from "./mux.ts";
 import type { SubagentParamsInput } from "./types.ts";
 import {
 	formatElapsed,
@@ -159,6 +166,16 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 	pi.on("session_start", (event, ctx) => {
 		latestContext = ctx;
 		resetSubagentBatchStopRequest();
+		if (getMuxBackend() === "zellij") {
+			const runtime = initializeZellijRuntimeContext(ctx.cwd);
+			traceSubagentLaunch("zellij.runtime", {
+				sessionName: runtime?.sessionName,
+				parentPaneId: runtime?.parentPaneId,
+				error: runtime ? undefined : getZellijRuntimeError(),
+			});
+		} else {
+			resetZellijRuntimeContext();
+		}
 		applySubagentLineage(ctx);
 		attachWidgetContext(ctx);
 

--- a/test/mux/mux.test.ts
+++ b/test/mux/mux.test.ts
@@ -605,6 +605,8 @@ fi
 				"zellij",
 				`#!/bin/sh
 printf '%s | pane=%s\n' "$*" "\${ZELLIJ_PANE_ID:-}" >> "$FAKE_ZELLIJ_LOG"
+# Production commands now target the discovered session explicitly. Strip that
+# prefix so this fake can keep asserting the action-level behavior below.
 if [ "$1" = "--session" ]; then shift 2; fi
 [ "$1" = "action" ] || exit 0
 action="$2"
@@ -630,6 +632,8 @@ fi
 			process.env.FAKE_ZELLIJ_SCREEN = screenFile;
 			process.env.FAKE_ZELLIJ_PANE_ID = "7";
 			process.env.ZELLIJ_PANE_ID = "3";
+			// The fake backend starts below session_start, so seed the resolved identity
+			// that production wiring would have cached before any action is sent.
 			setZellijRuntimeContextForTests({
 				sessionName: "fake-zellij",
 				parentPaneId: 3,

--- a/test/mux/mux.test.ts
+++ b/test/mux/mux.test.ts
@@ -32,6 +32,10 @@ import {
 	writeExecutable,
 	ORIGINAL_ENV,
 } from "../support/index.ts";
+import {
+	resetZellijRuntimeContext,
+	setZellijRuntimeContextForTests,
+} from "../../src/mux/core.ts";
 
 describe("mux.ts", () => {
 	describe("shellEscape", () => {
@@ -601,6 +605,7 @@ fi
 				"zellij",
 				`#!/bin/sh
 printf '%s | pane=%s\n' "$*" "\${ZELLIJ_PANE_ID:-}" >> "$FAKE_ZELLIJ_LOG"
+if [ "$1" = "--session" ]; then shift 2; fi
 [ "$1" = "action" ] || exit 0
 action="$2"
 if [ "$action" = "new-pane" ]; then
@@ -625,6 +630,10 @@ fi
 			process.env.FAKE_ZELLIJ_SCREEN = screenFile;
 			process.env.FAKE_ZELLIJ_PANE_ID = "7";
 			process.env.ZELLIJ_PANE_ID = "3";
+			setZellijRuntimeContextForTests({
+				sessionName: "fake-zellij",
+				parentPaneId: 3,
+			});
 
 			assert.equal(isZellijAvailable(), true);
 			const surface = createSurfaceSplit("Fake Zellij", "up", "pane:3");
@@ -646,6 +655,7 @@ fi
 			assert.doesNotMatch(log, /rename-tab/);
 			assert.match(log, /dump-screen --pane-id 7/);
 			assert.match(log, /close-pane --pane-id 7/);
+			resetZellijRuntimeContext();
 		});
 	});
 });

--- a/test/mux/zellij-owned-placement.test.ts
+++ b/test/mux/zellij-owned-placement.test.ts
@@ -78,6 +78,8 @@ describe("owned Zellij surface placement", () => {
 			binary,
 			`#!/bin/sh
 printf '%s | pane=%s\n' "$*" "\${ZELLIJ_PANE_ID:-}" >> "$FAKE_ZELLIJ_LOG"
+# Production commands now target the discovered session explicitly. Strip that
+# prefix so this fake can keep asserting the action-level behavior below.
 if [ "$1" = "--session" ]; then shift 2; fi
 [ "$1" = "action" ] || exit 0
 action="$2"
@@ -115,6 +117,8 @@ fi
 		process.env.FAKE_ZELLIJ_COUNTER = counterFile;
 		process.env.PI_SUBAGENT_ZELLIJ_MIN_COLUMNS = "50";
 		process.env.PI_SUBAGENT_ZELLIJ_MIN_ROWS = "10";
+		// This fake exercises placement after session_start, so provide the resolved
+		// identity without requiring a real Zellij server during the test.
 		setZellijRuntimeContextForTests({
 			sessionName: process.env.ZELLIJ_SESSION_NAME!,
 			parentPaneId: 10,

--- a/test/mux/zellij-owned-placement.test.ts
+++ b/test/mux/zellij-owned-placement.test.ts
@@ -5,6 +5,10 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 
 import {
+	resetZellijRuntimeContext,
+	setZellijRuntimeContextForTests,
+} from "../../src/mux/core.ts";
+import {
 	createZellijSurface,
 	resetZellijPlacementStateForTests,
 	type ZellijPlacementContext,
@@ -74,6 +78,7 @@ describe("owned Zellij surface placement", () => {
 			binary,
 			`#!/bin/sh
 printf '%s | pane=%s\n' "$*" "\${ZELLIJ_PANE_ID:-}" >> "$FAKE_ZELLIJ_LOG"
+if [ "$1" = "--session" ]; then shift 2; fi
 [ "$1" = "action" ] || exit 0
 action="$2"
 if [ "$action" = "list-panes" ]; then
@@ -110,10 +115,15 @@ fi
 		process.env.FAKE_ZELLIJ_COUNTER = counterFile;
 		process.env.PI_SUBAGENT_ZELLIJ_MIN_COLUMNS = "50";
 		process.env.PI_SUBAGENT_ZELLIJ_MIN_ROWS = "10";
+		setZellijRuntimeContextForTests({
+			sessionName: process.env.ZELLIJ_SESSION_NAME!,
+			parentPaneId: 10,
+		});
 	});
 
 	afterEach(() => {
 		resetZellijPlacementStateForTests();
+		resetZellijRuntimeContext();
 		for (const key of trackedEnv) {
 			const value = originalEnv[key];
 			if (value === undefined) delete process.env[key];

--- a/test/mux/zellij-placement.test.ts
+++ b/test/mux/zellij-placement.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 
 import { zellijPlacementGroupId } from "../../src/mux/zellij-anchor-state.ts";
+import {
+	resetZellijRuntimeContext,
+	resolveZellijRuntimeContextFromSnapshots,
+	setZellijRuntimeContextForTests,
+} from "../../src/mux/core.ts";
 import {
 	canSplitZellijPaneInDirection,
 	resolveZellijPlacementPolicy,
@@ -11,6 +16,17 @@ import {
 } from "../../src/mux/zellij-placement.ts";
 
 describe("zellij placement", () => {
+	beforeEach(() => {
+		setZellijRuntimeContextForTests({
+			sessionName: "Foo",
+			parentPaneId: 1,
+		});
+	});
+
+	afterEach(() => {
+		resetZellijRuntimeContext();
+	});
+
 	const pane = (overrides: Partial<ZellijPaneSnapshot>): ZellijPaneSnapshot => ({
 		id: 1,
 		is_plugin: false,
@@ -167,5 +183,64 @@ describe("zellij placement", () => {
 			pane({ id: 33, is_selectable: false }),
 		];
 		assert.equal(selectLiveOwnedZellijAnchor(panes, [31, 32, 33]), null);
+	});
+
+	it("resolves a renamed session from pane cwd instead of stale environment", () => {
+		const runtime = resolveZellijRuntimeContextFromSnapshots(
+			1,
+			"/workspace/Foo",
+			[
+				{
+					name: "Bar",
+					panes: [{ id: 1, pane_cwd: "/workspace/other" }],
+					clientPaneIds: [],
+				},
+				{
+					name: "Foo",
+					panes: [{ id: 1, pane_cwd: "/workspace/Foo" }],
+					clientPaneIds: [1],
+				},
+			],
+		);
+
+		assert.deepEqual(runtime, { sessionName: "Foo", parentPaneId: 1 });
+	});
+
+	it("resolves a non-focused child pane from live pane state", () => {
+		const runtime = resolveZellijRuntimeContextFromSnapshots(
+			10,
+			"/workspace/project",
+			[
+				{
+					name: "Foo",
+					panes: [
+						{ id: 12, pane_cwd: "/workspace/project" },
+						{ id: 10, pane_cwd: "/workspace/project" },
+					],
+					clientPaneIds: [12],
+				},
+			],
+		);
+
+		assert.equal(runtime.sessionName, "Foo");
+	});
+
+	it("rejects unresolved pane collisions", () => {
+		assert.throws(
+			() =>
+				resolveZellijRuntimeContextFromSnapshots(1, "/workspace/project", [
+					{
+						name: "Foo",
+						panes: [{ id: 1, pane_cwd: "/other/foo" }],
+						clientPaneIds: [],
+					},
+					{
+						name: "Bar",
+						panes: [{ id: 1, pane_cwd: "/other/bar" }],
+						clientPaneIds: [],
+					},
+				]),
+			/matches multiple sessions: Foo, Bar/,
+		);
 	});
 });

--- a/test/mux/zellij-placement.test.ts
+++ b/test/mux/zellij-placement.test.ts
@@ -17,6 +17,8 @@ import {
 
 describe("zellij placement", () => {
 	beforeEach(() => {
+		// Pure placement tests do not start Pi or a Zellij server, so seed the
+		// session_start result they would normally receive from extension wiring.
 		setZellijRuntimeContextForTests({
 			sessionName: "Foo",
 			parentPaneId: 1,
@@ -186,6 +188,8 @@ describe("zellij placement", () => {
 	});
 
 	it("resolves a renamed session from pane cwd instead of stale environment", () => {
+		// Reproduces a renamed session where the process still names Bar while its
+		// pane and working directory belong to Foo.
 		const runtime = resolveZellijRuntimeContextFromSnapshots(
 			1,
 			"/workspace/Foo",
@@ -207,6 +211,8 @@ describe("zellij placement", () => {
 	});
 
 	it("resolves a non-focused child pane from live pane state", () => {
+		// Child agents are commonly not focused, so discovery must not require the
+		// attached client's pane ID to equal the child pane ID.
 		const runtime = resolveZellijRuntimeContextFromSnapshots(
 			10,
 			"/workspace/project",
@@ -226,6 +232,8 @@ describe("zellij placement", () => {
 	});
 
 	it("rejects unresolved pane collisions", () => {
+		// Guessing here could send keystrokes to an unrelated session. Ambiguous
+		// identity must remain an explicit launch error.
 		assert.throws(
 			() =>
 				resolveZellijRuntimeContextFromSnapshots(1, "/workspace/project", [


### PR DESCRIPTION
## Summary

- Discover the live Zellij session during Pi's `session_start` event instead of trusting `ZELLIJ_SESSION_NAME`.
- Resolve the session from the current pane ID, pane cwd, and attached-client state.
- Cache the resolved `{ sessionName, parentPaneId }` for the Pi session.
- Target every Zellij action explicitly with `zellij --session <name> action ...`.
- Scope Zellij placement state and locks to the resolved session name.

## Problem

`ZELLIJ_SESSION_NAME` is inherited by the shell when a pane starts. If the Zellij session is renamed later, an existing Pi process can retain the old name. Interactive subagent launches then query the wrong session and can report zero attached clients even while the real session is attached.

The new resolver enumerates live sessions and their panes once at Pi session startup. It supports non-focused child panes and fails explicitly when pane identity remains ambiguous.

Related upstream Zellij behavior: zellij-org/zellij#5047.

## Testing

- `npm test` — 447 passed, 4 skipped, 0 failed
- Targeted Zellij placement tests — 20 passed
- Fake Zellij backend integration test — passed
- `npx tsc --noEmit` — passed
- Live stale-environment reproduction resolved `Bar` to `Foo` and routed actions to `Foo`
