### PR TITLE
fix: don't discard a subagent's result after a recovered provider error

### DIFF
--- a/src/auto-exit.ts
+++ b/src/auto-exit.ts
@@ -13,7 +13,7 @@ const NON_RETRYABLE_PROVIDER_ERROR_PATTERN =
 	/GoUsageLimitError|FreeUsageLimitError|Monthly usage limit reached|available balance|insufficient_quota|out of budget|quota exceeded|billing/i;
 
 const RETRYABLE_PROVIDER_ERROR_PATTERN =
-	/overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|stream ended before message_stop|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
+	/overloaded|provider.?returned.?error|an error occurred while processing your request|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|stream ended before message_stop|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
 
 export function isRetryableProviderErrorMessage(errorMessage: string): boolean {
 	if (NON_RETRYABLE_PROVIDER_ERROR_PATTERN.test(errorMessage)) return false;

--- a/src/runtime/background-watch.ts
+++ b/src/runtime/background-watch.ts
@@ -1,7 +1,7 @@
 import { existsSync, statSync } from "node:fs";
 import { consumeSubagentExitSignal } from "../mux.ts";
-import type { RunningSubagent, SessionEntryLike, SubagentResult } from "../types.ts";
-import { findLastSubagentOutput, getEntries, getEntryCount, getNewEntries } from "../session/session.ts";
+import type { RunningSubagent, SessionEntryLike, SubagentResult, SubagentSummarySource } from "../types.ts";
+import { findLastSubagentOutputWithSource, getEntries, getEntryCount, getNewEntries } from "../session/session.ts";
 import { getTerminalAssistantSummary, shouldReapStableTerminalSummary } from "../agents/titles.ts";
 
 export interface BackgroundWatchRuntime {
@@ -108,20 +108,26 @@ export function watchBackgroundSubagent(
 			const stderr = running.stderrTail?.trim();
 			const stdout = running.stdoutTail?.trim();
 			let summary = `Background agent exited with code ${exitCode}`;
+			let summarySource: SubagentSummarySource = "runtime";
 			if (!running.noSession && existsSync(running.sessionFile)) {
 				const allEntries = getNewEntries(
 					running.sessionFile,
 					running.launchEntryCount ?? 0,
 				);
-				summary =
-					findLastSubagentOutput(allEntries) ??
-					(exitCode !== 0 && stderr
-						? `Background agent exited with code ${exitCode}\n\n${stderr}`
-						: exitCode !== 0
-							? `Background agent exited with code ${exitCode}`
-							: stdout || "Background agent exited without output");
+				const output = findLastSubagentOutputWithSource(allEntries);
+				if (output) {
+					({ summary, summarySource } = output);
+				} else if (exitCode !== 0 && stderr) {
+					summary = `Background agent exited with code ${exitCode}\n\n${stderr}`;
+				} else if (exitCode === 0 && stdout) {
+					summary = stdout;
+					summarySource = "subagent";
+				} else if (exitCode === 0) {
+					summary = "Background agent exited without output";
+				}
 			} else if (stdout) {
 				summary = stdout;
+				summarySource = "subagent";
 			} else if (exitCode !== 0 && stderr) {
 				summary = `Background agent exited with code ${exitCode}\n\n${stderr}`;
 			}
@@ -129,6 +135,7 @@ export function watchBackgroundSubagent(
 				name: running.name,
 				task: running.task,
 				summary,
+				summarySource,
 				sessionFile: running.noSession ? undefined : running.sessionFile,
 				exitCode,
 				elapsed,
@@ -142,6 +149,7 @@ export function watchBackgroundSubagent(
 				name: running.name,
 				task: running.task,
 				summary: `Background agent failed to start: ${error.message}`,
+				summarySource: "runtime",
 				sessionFile: running.noSession ? undefined : running.sessionFile,
 				exitCode: 1,
 				elapsed: Math.floor((Date.now() - running.startTime) / 1000),

--- a/src/runtime/interactive-watch.ts
+++ b/src/runtime/interactive-watch.ts
@@ -2,8 +2,8 @@ import { existsSync, readFileSync, rmSync, statSync } from "node:fs";
 import { consumeSubagentExitSignal, getMuxBackend, pollForExit } from "../mux.ts";
 import type { PollResult } from "../mux/poll.ts";
 import { isZellijSurfaceLive } from "../mux/zellij-runtime.ts";
-import type { RunningSubagent, SubagentResult } from "../types.ts";
-import { findLastSubagentOutput, getNewEntries } from "../session/session.ts";
+import type { RunningSubagent, SubagentResult, SubagentSummarySource } from "../types.ts";
+import { findLastSubagentOutputWithSource, getNewEntries } from "../session/session.ts";
 import { traceSubagentLaunch } from "../launch/trace.ts";
 
 export interface InteractiveWatchRuntime {
@@ -43,7 +43,7 @@ export async function watchSubagent(
 
 		traceSubagentLaunch("interactive.watch.pollResult", { name, surface, sessionFile, pollResult });
 		const elapsed = Math.floor((Date.now() - startTime) / 1000);
-		const summary = getSummary(running, pollResult);
+		const { summary, summarySource } = getSummary(running, pollResult);
 		const errorMessage = pollResult.reason === "error" ? pollResult.errorMessage : undefined;
 		const exitSignal = pollResult.outputTokens === undefined
 			? consumeSubagentExitSignal(sessionFile)
@@ -58,6 +58,7 @@ export async function watchSubagent(
 			name,
 			task,
 			summary,
+			summarySource,
 			sessionFile: running.noSession ? undefined : sessionFile,
 			exitCode: pollResult.exitCode,
 			elapsed,
@@ -79,6 +80,7 @@ export async function watchSubagent(
 				name,
 				task,
 				summary: "Subagent cancelled.",
+				summarySource: "runtime",
 				exitCode: 1,
 				elapsed: Math.floor((Date.now() - startTime) / 1000),
 				outputTokens: 0,
@@ -89,6 +91,7 @@ export async function watchSubagent(
 			name,
 			task,
 			summary: `Subagent error: ${errorMessage}`,
+			summarySource: "runtime",
 			exitCode: 1,
 			elapsed: Math.floor((Date.now() - startTime) / 1000),
 			outputTokens: 0,
@@ -97,16 +100,22 @@ export async function watchSubagent(
 	}
 }
 
-function getSummary(running: RunningSubagent, pollResult: PollResult): string {
+function getSummary(
+	running: RunningSubagent,
+	pollResult: PollResult,
+): { summary: string; summarySource: SubagentSummarySource } {
 	if (!running.noSession && existsSync(running.sessionFile)) {
-		const output = findLastSubagentOutput(
+		const output = findLastSubagentOutputWithSource(
 			getNewEntries(running.sessionFile, running.launchEntryCount ?? 0),
 		);
 		if (output) return output;
 	}
-	return pollResult.exitCode !== 0
-		? `Sub-agent exited with code ${pollResult.exitCode}`
-		: "Sub-agent exited without output";
+	return {
+		summary: pollResult.exitCode !== 0
+			? `Sub-agent exited with code ${pollResult.exitCode}`
+			: "Sub-agent exited without output",
+		summarySource: "runtime",
+	};
 }
 
 async function pollForZellijFiles(

--- a/src/runtime/result-router.ts
+++ b/src/runtime/result-router.ts
@@ -150,7 +150,7 @@ function getCompletedSubagentContent(
 	sessionRef: string,
 ): string {
 	if (completed.errorMessage) {
-		const resultBody = hasRealSubagentOutput(completed.summary)
+		const resultBody = hasRealSubagentOutput(completed)
 			? `Last output before the failure (may be incomplete — verify before trusting):\n\n${completed.summary}`
 			: `The subagent did not produce a result. You can retry by spawning a new ` +
 				`subagent or resume the session with subagent_resume.`;

--- a/src/runtime/result-router.ts
+++ b/src/runtime/result-router.ts
@@ -8,6 +8,7 @@ import {
 	buildCompletedSubagentResult,
 	cacheCompletedSubagentResult,
 	clearSubagentShutdownTimer,
+	hasRealSubagentOutput,
 	runningSubagents,
 	stopAfterCurrentSubagentBatch,
 } from "./state.ts";
@@ -149,12 +150,14 @@ function getCompletedSubagentContent(
 	sessionRef: string,
 ): string {
 	if (completed.errorMessage) {
+		const resultBody = hasRealSubagentOutput(completed.summary)
+			? `Last output before the failure (may be incomplete — verify before trusting):\n\n${completed.summary}`
+			: `The subagent did not produce a result. You can retry by spawning a new ` +
+				`subagent or resume the session with subagent_resume.`;
 		return (
 			`Sub-agent "${completed.name}" failed after ${formatElapsed(completed.elapsed)} ` +
 			`(provider/agent error — auto-retry exhausted).\n\n` +
-			`Error: ${completed.errorMessage}\n\n` +
-			`The subagent did not produce a result. You can retry by spawning a new ` +
-			`subagent or resume the session with subagent_resume.${sessionRef}`
+			`Error: ${completed.errorMessage}\n\n${resultBody}${sessionRef}`
 		);
 	}
 	return completed.exitCode !== 0

--- a/src/runtime/state.ts
+++ b/src/runtime/state.ts
@@ -42,7 +42,7 @@ function getSubagentCompletionStatus(
  * for a child that exited without answering. Used to tell an operator pane-close
  * of a manual interactive child apart from a crash before it produced output.
  */
-function hasRealSubagentOutput(summary: string | undefined): boolean {
+export function hasRealSubagentOutput(summary: string | undefined): boolean {
 	const text = (summary ?? "").trim();
 	if (!text) return false;
 	return (

--- a/src/runtime/state.ts
+++ b/src/runtime/state.ts
@@ -30,25 +30,18 @@ function getSubagentCompletionStatus(
 		running?.mode === "interactive" &&
 		running.autoExit === false &&
 		!result.error &&
-		hasRealSubagentOutput(result.summary)
+		hasRealSubagentOutput(result)
 	) {
 		return "completed";
 	}
 	return "failed";
 }
 
-/**
- * True when the summary is a real child result rather than a watcher fallback
- * for a child that exited without answering. Used to tell an operator pane-close
- * of a manual interactive child apart from a crash before it produced output.
- */
-export function hasRealSubagentOutput(summary: string | undefined): boolean {
-	const text = (summary ?? "").trim();
-	if (!text) return false;
-	return (
-		!text.startsWith("Sub-agent exited with code ") &&
-		text !== "Sub-agent exited without output"
-	);
+/** True when the summary came from the child rather than runtime diagnostics. */
+export function hasRealSubagentOutput(
+	result: Pick<SubagentResult, "summary" | "summarySource">,
+): boolean {
+	return result.summarySource !== "runtime" && result.summary.trim() !== "";
 }
 
 export function buildCompletedSubagentResult(

--- a/src/runtime/wait-result.ts
+++ b/src/runtime/wait-result.ts
@@ -46,7 +46,7 @@ function getSubagentWaitSuccessResult(cached: CompletedSubagentResult) {
 		: "";
 	let text: string;
 	if (cached.errorMessage) {
-		const resultBody = hasRealSubagentOutput(cached.summary)
+		const resultBody = hasRealSubagentOutput(cached)
 			? `Last output before the failure (may be incomplete — verify before trusting):\n\n${cached.summary}`
 			: `The subagent did not produce a result. You can retry by spawning a new ` +
 				`subagent or resume the session with subagent_resume.`;

--- a/src/runtime/wait-result.ts
+++ b/src/runtime/wait-result.ts
@@ -6,6 +6,7 @@ import type {
 	SubagentResult,
 	WaitParams,
 } from "../types.ts";
+import { hasRealSubagentOutput } from "./state.ts";
 import { formatElapsed } from "./wiring.ts";
 import type { WaitRuntime } from "./wait.ts";
 
@@ -20,7 +21,8 @@ function getSubagentWaitPingResult(
 				type: "text",
 				text:
 					`Sub-agent "${running.name}" requested help and exited. ` +
-					`Resume it with subagent_resume using sessionFile ${result.sessionFile ?? "(missing)"}.`,
+					`Resume it with subagent_resume using sessionFile ${result.sessionFile ?? "(missing)"}.` +
+					`\n\nMessage from the subagent:\n${result.ping?.message ?? ""}`,
 			},
 		],
 		details: {
@@ -44,12 +46,14 @@ function getSubagentWaitSuccessResult(cached: CompletedSubagentResult) {
 		: "";
 	let text: string;
 	if (cached.errorMessage) {
+		const resultBody = hasRealSubagentOutput(cached.summary)
+			? `Last output before the failure (may be incomplete — verify before trusting):\n\n${cached.summary}`
+			: `The subagent did not produce a result. You can retry by spawning a new ` +
+				`subagent or resume the session with subagent_resume.`;
 		text =
 			`Sub-agent "${cached.name}" failed after ${formatElapsed(cached.elapsed)} ` +
 			`(provider/agent error — auto-retry exhausted).\n\n` +
-			`Error: ${cached.errorMessage}\n\n` +
-			`The subagent did not produce a result. You can retry by spawning a new ` +
-			`subagent or resume the session with subagent_resume.${sessionRef}`;
+			`Error: ${cached.errorMessage}\n\n${resultBody}${sessionRef}`;
 	} else {
 		const verb =
 			cached.status === "completed"

--- a/src/session/exit-sidecar.ts
+++ b/src/session/exit-sidecar.ts
@@ -22,7 +22,8 @@ export function writeSubagentExitSidecar(
 			};
 			if (existing.type !== "error") return;
 		} catch {
-			return;
+			// A consumed or unreadable sidecar carries no verdict worth protecting.
+			// Let a genuine completion replace it.
 		}
 	}
 	writeFileSync(exitFile, JSON.stringify(payload), "utf8");

--- a/src/session/exit-sidecar.ts
+++ b/src/session/exit-sidecar.ts
@@ -1,4 +1,4 @@
-import { rmSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 
 export function getSubagentExitSidecarPath(sessionFile: string): string {
 	return `${sessionFile}.exit`;
@@ -6,4 +6,24 @@ export function getSubagentExitSidecarPath(sessionFile: string): string {
 
 export function clearSubagentExitSidecar(sessionFile: string): void {
 	rmSync(getSubagentExitSidecarPath(sessionFile), { force: true });
+}
+
+export function writeSubagentExitSidecar(
+	sessionFile: string,
+	payload: object,
+	opts?: { supersede?: boolean },
+): void {
+	const exitFile = getSubagentExitSidecarPath(sessionFile);
+	if (existsSync(exitFile)) {
+		if (!opts?.supersede) return;
+		try {
+			const existing = JSON.parse(readFileSync(exitFile, "utf8")) as {
+				type?: unknown;
+			};
+			if (existing.type !== "error") return;
+		} catch {
+			return;
+		}
+	}
+	writeFileSync(exitFile, JSON.stringify(payload), "utf8");
 }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -5,6 +5,7 @@ import {
 	CALLER_PING_TOOL_NAME,
 	SUBAGENT_DONE_TOOL_NAME,
 } from "../tools/tool-names.ts";
+import type { SubagentSummarySource } from "../types.ts";
 
 export interface SessionEntry {
 	type: string;
@@ -107,28 +108,40 @@ export function getSubagentTerminalStopReason(summary: string): string | null {
 	return match?.[1]?.trim() || null;
 }
 
-export function findLastAssistantMessage(
-	entries: SessionEntry[],
-): string | null {
+export interface SubagentOutput {
+	summary: string;
+	summarySource: SubagentSummarySource;
+}
+
+function findLastAssistantOutput(entries: SessionEntry[]): SubagentOutput | null {
 	for (let i = entries.length - 1; i >= 0; i--) {
 		const entry = entries[i];
 		if (entry.type !== "message") continue;
 		const msg = entry as MessageEntry;
 		if (msg.message.role !== "assistant") continue;
 		const text = getTextContent(msg);
-		if (text) return text;
+		if (text) return { summary: text, summarySource: "subagent" };
 
 		// A terminal assistant turn with no text is still the child outcome.
-		// Surface it instead of scanning past it to stale earlier status text.
+		// Mark the synthesized status as runtime-owned instead of presenting it as
+		// the child's work.
 		const stopMessage = getTerminalStopMessage(msg);
-		if (stopMessage) return stopMessage;
+		if (stopMessage) return { summary: stopMessage, summarySource: "runtime" };
 	}
 	return null;
 }
 
-export function findLastSubagentOutput(entries: SessionEntry[]): string | null {
-	const assistantText = findLastAssistantMessage(entries);
-	if (assistantText) return assistantText;
+export function findLastAssistantMessage(
+	entries: SessionEntry[],
+): string | null {
+	return findLastAssistantOutput(entries)?.summary ?? null;
+}
+
+export function findLastSubagentOutputWithSource(
+	entries: SessionEntry[],
+): SubagentOutput | null {
+	const assistantOutput = findLastAssistantOutput(entries);
+	if (assistantOutput) return assistantOutput;
 
 	for (let i = entries.length - 1; i >= 0; i--) {
 		const entry = entries[i];
@@ -138,9 +151,13 @@ export function findLastSubagentOutput(entries: SessionEntry[]): string | null {
 		if (msg.message.toolName === SUBAGENT_DONE_TOOL_NAME) continue;
 		if (msg.message.toolName === CALLER_PING_TOOL_NAME) continue;
 		const text = getTextContent(msg);
-		if (text) return text;
+		if (text) return { summary: text, summarySource: "subagent" };
 	}
 	return null;
+}
+
+export function findLastSubagentOutput(entries: SessionEntry[]): string | null {
+	return findLastSubagentOutputWithSource(entries)?.summary ?? null;
 }
 
 export function appendBranchSummary(

--- a/src/tools/subagent-done.ts
+++ b/src/tools/subagent-done.ts
@@ -3,7 +3,6 @@
  * - Provides a `subagent_done` tool for autonomous agents to self-terminate
  */
 
-import { existsSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
@@ -14,6 +13,7 @@ import {
 } from "../auto-exit.ts";
 import { ProviderErrorRecoveryController, resolveProviderRecoveryDelaysMs } from "./provider-error-recovery.ts";
 import { PI_SUBAGENT_APPEND_SYSTEM_PROMPT } from "../launch/append-system.ts";
+import { writeSubagentExitSidecar } from "../session/exit-sidecar.ts";
 import {
 	CALLER_PING_TOOL_NAME,
 	SUBAGENT_DONE_TOOL_NAME,
@@ -176,12 +176,13 @@ export default function (pi: ExtensionAPI) {
 		}, 0);
 	}
 
-	function writeExitSignal(payload: object) {
+	function writeExitSignal(
+		payload: object,
+		opts?: { supersede?: boolean },
+	) {
 		const sessionFile = process.env.PI_SUBAGENT_SESSION;
 		if (!sessionFile) return;
-		const exitFile = `${sessionFile}.exit`;
-		if (existsSync(exitFile)) return;
-		writeFileSync(exitFile, JSON.stringify(payload), "utf8");
+		writeSubagentExitSidecar(sessionFile, payload, opts);
 	}
 
 	const subagentName = process.env.PI_SUBAGENT_NAME ?? "";
@@ -436,12 +437,9 @@ export default function (pi: ExtensionAPI) {
 				if (errorInfo.recoveryKind === "none") {
 					providerErrorRecovery.cancelPendingRecovery();
 					cancelPendingPiRecovery();
-					writeExitSignal({
-						type: "error",
-						errorMessage: errorInfo.errorMessage,
-						stopReason: errorInfo.stopReason,
-						outputTokens,
-					});
+					// Defer stamping the failure while Pi's in-flight retry may still
+					// recover. If the child really dies, session_shutdown reports it
+					// from pendingProviderError.
 					requestShutdown(ctx);
 					return;
 				}
@@ -453,7 +451,7 @@ export default function (pi: ExtensionAPI) {
 			pendingProviderError = null;
 			providerErrorRecovery.cancelPendingRecovery(true);
 			cancelPendingPiRecovery();
-			writeExitSignal({ type: "done", outputTokens });
+			writeExitSignal({ type: "done", outputTokens }, { supersede: true });
 			requestShutdown(ctx);
 		});
 	}
@@ -483,7 +481,7 @@ export default function (pi: ExtensionAPI) {
 				name: process.env.PI_SUBAGENT_NAME ?? "subagent",
 				message: params.message,
 				outputTokens,
-			});
+			}, { supersede: true });
 			requestShutdown(ctx);
 			return {
 				content: [
@@ -505,7 +503,7 @@ export default function (pi: ExtensionAPI) {
 				"Your LAST assistant message before calling this becomes the summary returned to the caller.",
 			parameters: doneParams,
 			async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
-				writeExitSignal({ type: "done", outputTokens });
+				writeExitSignal({ type: "done", outputTokens }, { supersede: true });
 				requestShutdown(ctx);
 				return {
 					content: [{ type: "text", text: "Shutting down subagent session." }],

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type DeliveryState = "detached" | "awaited";
 export type ParentClosePolicy = "terminate" | "continue";
 type CompletedDelivery = "steer" | "wait";
 export type SubagentCompletionStatus = "completed" | "failed" | "cancelled";
+export type SubagentSummarySource = "subagent" | "runtime";
 export type ParentShutdownAction = "terminate" | "continue";
 
 export interface SubagentParamsInput {
@@ -39,6 +40,8 @@ export interface SubagentResult {
 	name: string;
 	task: string;
 	summary: string;
+	/** Origin of the summary text. Omitted legacy results are treated as subagent output. */
+	summarySource?: SubagentSummarySource;
 	sessionFile?: string;
 	exitCode: number;
 	elapsed: number;

--- a/test/auto-exit.test.ts
+++ b/test/auto-exit.test.ts
@@ -94,6 +94,12 @@ describe("isRetryableProviderErrorMessage", () => {
 		assert.equal(isRetryableProviderErrorMessage("HTTP 429 rate limit"), true);
 		assert.equal(isRetryableProviderErrorMessage("service unavailable"), true);
 		assert.equal(isRetryableProviderErrorMessage("stream ended before message_stop"), true);
+		assert.equal(
+			isRetryableProviderErrorMessage(
+				"Codex error: An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com.",
+			),
+			true,
+		);
 	});
 
 	it("rejects permanent quota, billing, and auth failures", () => {

--- a/test/runtime/result-router.test.ts
+++ b/test/runtime/result-router.test.ts
@@ -74,6 +74,31 @@ describe("result router", () => {
 		assert.deepEqual(sent[0].options, { triggerTurn: true, deliverAs: "steer" });
 	});
 
+	it("delivers salvaged child output with provider errors", () => {
+		const sent: Array<{ message: any; options: any }> = [];
+		const running = makeRunning();
+		setRunningSubagentForTest(running);
+
+		routeSubagentOutcome({
+			pi: {
+				sendMessage(message: any, options: any) {
+					sent.push({ message, options });
+				},
+			},
+			running,
+			result: makeResult({
+				summary: "Completed the requested implementation.",
+				errorMessage: "Provider unavailable",
+			}),
+			formatElapsed: (seconds) => `${seconds}s`,
+			updateWidget: () => {},
+		});
+
+		assert.match(sent[0].message.content, /Last output before the failure/);
+		assert.match(sent[0].message.content, /Completed the requested implementation\./);
+		assert.doesNotMatch(sent[0].message.content, /did not produce a result/);
+	});
+
 	it("routes child pings without caching a completed result", () => {
 		const sent: Array<{ message: any; options: any }> = [];
 		let widgetUpdates = 0;
@@ -106,6 +131,7 @@ describe("result router", () => {
 		assert.equal(sent[0].message.customType, "subagent_ping");
 		assert.equal(sent[0].message.details.id, running.id);
 		assert.equal(sent[0].message.details.message, "Need parent input.");
+		assert.match(sent[0].message.content, /Need parent input\./);
 		assert.deepEqual(sent[0].options, { triggerTurn: true, deliverAs: "steer" });
 	});
 });

--- a/test/runtime/result-router.test.ts
+++ b/test/runtime/result-router.test.ts
@@ -31,6 +31,7 @@ function makeResult(overrides: Partial<SubagentResult> = {}): SubagentResult {
 		name: "Result child",
 		task: "Report result",
 		summary: "Finished the delegated work.",
+		summarySource: "subagent",
 		sessionFile: "/tmp/result-child.jsonl",
 		exitCode: 0,
 		elapsed: 3,
@@ -97,6 +98,32 @@ describe("result router", () => {
 		assert.match(sent[0].message.content, /Last output before the failure/);
 		assert.match(sent[0].message.content, /Completed the requested implementation\./);
 		assert.doesNotMatch(sent[0].message.content, /did not produce a result/);
+	});
+
+	it("does not present runtime diagnostics as salvaged child output", () => {
+		const sent: Array<{ message: any; options: any }> = [];
+		const running = makeRunning();
+		setRunningSubagentForTest(running);
+
+		routeSubagentOutcome({
+			pi: {
+				sendMessage(message: any, options: any) {
+					sent.push({ message, options });
+				},
+			},
+			running,
+			result: makeResult({
+				summary: "Background agent exited with code 1\n\nprovider stack trace",
+				summarySource: "runtime",
+				errorMessage: "Provider unavailable",
+			}),
+			formatElapsed: (seconds) => `${seconds}s`,
+			updateWidget: () => {},
+		});
+
+		assert.match(sent[0].message.content, /did not produce a result/);
+		assert.doesNotMatch(sent[0].message.content, /Last output before the failure/);
+		assert.doesNotMatch(sent[0].message.content, /provider stack trace/);
 	});
 
 	it("routes child pings without caching a completed result", () => {

--- a/test/runtime/state.test.ts
+++ b/test/runtime/state.test.ts
@@ -25,6 +25,7 @@ function makeResult(overrides: Partial<SubagentResult> = {}): SubagentResult {
 		name: "test-agent",
 		task: "test task",
 		summary: "done",
+		summarySource: "subagent",
 		exitCode: 0,
 		elapsed: 5,
 		...overrides,
@@ -69,7 +70,11 @@ describe("getSubagentCompletionStatus (via buildCompletedSubagentResult)", () =>
 		// when there is a real final message to return.
 		const result = buildCompletedSubagentResult(
 			makeRunning({ mode: "interactive", autoExit: false }),
-			makeResult({ exitCode: 1, summary: "Sub-agent exited with code 1" }),
+			makeResult({
+				exitCode: 1,
+				summary: "Sub-agent exited with code 1",
+				summarySource: "runtime",
+			}),
 		);
 		assert.equal(result.status, "failed");
 	});

--- a/test/runtime/wait.test.ts
+++ b/test/runtime/wait.test.ts
@@ -16,6 +16,68 @@ describe("subagent wait behavior", () => {
 		resetSubagentStateForTest();
 	});
 
+	function waitForResult(result: any) {
+		const running = {
+			id: `child-wait-${Math.random()}`,
+			name: result.name,
+			task: result.task,
+			mode: "background" as const,
+			executionState: "running" as const,
+			deliveryState: "detached" as const,
+			parentClosePolicy: "terminate" as const,
+			startTime: Date.now(),
+			sessionFile: result.sessionFile,
+			completionPromise: Promise.resolve(result),
+		};
+		setRunningSubagentForTest(running);
+		return waitForSubagentForTest({ id: running.id });
+	}
+
+	it("includes salvaged child output in provider error results", async () => {
+		const waited = await waitForResult({
+			name: "Failed child",
+			task: "Finish work",
+			summary: "Implemented the requested fix.",
+			sessionFile: "/tmp/failed-child.jsonl",
+			exitCode: 0,
+			elapsed: 2,
+			errorMessage: "Provider unavailable",
+		});
+		const text = (waited.content[0] as { text: string }).text;
+		assert.match(text, /Last output before the failure \(may be incomplete/);
+		assert.match(text, /Implemented the requested fix\./);
+		assert.doesNotMatch(text, /did not produce a result/);
+	});
+
+	it("reports no result when a provider error has only watcher fallback output", async () => {
+		const waited = await waitForResult({
+			name: "Failed child",
+			task: "Finish work",
+			summary: "Sub-agent exited without output",
+			sessionFile: "/tmp/failed-child.jsonl",
+			exitCode: 1,
+			elapsed: 2,
+			errorMessage: "Provider unavailable",
+		});
+		const text = (waited.content[0] as { text: string }).text;
+		assert.match(text, /The subagent did not produce a result\./);
+		assert.doesNotMatch(text, /Last output before the failure/);
+	});
+
+	it("includes the child message in ping results", async () => {
+		const waited = await waitForResult({
+			name: "Ping child",
+			task: "Investigate",
+			summary: "",
+			sessionFile: "/tmp/ping-child.jsonl",
+			exitCode: 0,
+			elapsed: 1,
+			ping: { name: "Ping child", message: "Which API version should I use?" },
+		});
+		const text = (waited.content[0] as { text: string }).text;
+		assert.match(text, /Message from the subagent:\nWhich API version should I use\?/);
+	});
+
 	it("returns cached result when wait follows steer delivery", async () => {
 		const sent: Array<{ message: any; options: any }> = [];
 		const running = {

--- a/test/runtime/wait.test.ts
+++ b/test/runtime/wait.test.ts
@@ -38,6 +38,7 @@ describe("subagent wait behavior", () => {
 			name: "Failed child",
 			task: "Finish work",
 			summary: "Implemented the requested fix.",
+			summarySource: "subagent",
 			sessionFile: "/tmp/failed-child.jsonl",
 			exitCode: 0,
 			elapsed: 2,
@@ -53,7 +54,8 @@ describe("subagent wait behavior", () => {
 		const waited = await waitForResult({
 			name: "Failed child",
 			task: "Finish work",
-			summary: "Sub-agent exited without output",
+			summary: "Background agent exited without output",
+			summarySource: "runtime",
 			sessionFile: "/tmp/failed-child.jsonl",
 			exitCode: 1,
 			elapsed: 2,

--- a/test/session/exit-sidecar.test.ts
+++ b/test/session/exit-sidecar.test.ts
@@ -54,6 +54,18 @@ describe("subagent exit sidecars", () => {
 		}
 	});
 
+	it("replaces an unreadable sidecar with a genuine completion", () => {
+		const dir = createTestDir();
+		const sessionFile = join(dir, "child.jsonl");
+		const exitFile = getSubagentExitSidecarPath(sessionFile);
+		const completion = { type: "done", outputTokens: 8 };
+		writeFileSync(exitFile, "{truncated");
+
+		writeSubagentExitSidecar(sessionFile, completion, { supersede: true });
+
+		assert.deepEqual(JSON.parse(readFileSync(exitFile, "utf8")), completion);
+	});
+
 	it("keeps first-write-wins behavior by default", () => {
 		const dir = createTestDir();
 		const sessionFile = join(dir, "child.jsonl");

--- a/test/session/exit-sidecar.test.ts
+++ b/test/session/exit-sidecar.test.ts
@@ -5,6 +5,7 @@ import { assert, createTestDir } from "../support/index.ts";
 import {
 	clearSubagentExitSidecar,
 	getSubagentExitSidecarPath,
+	writeSubagentExitSidecar,
 } from "../../src/session/exit-sidecar.ts";
 import { consumeSubagentExitSignal } from "../../src/mux/poll.ts";
 
@@ -24,6 +25,45 @@ describe("subagent exit sidecars", () => {
 		});
 		assert.equal(existsSync(exitFile), false);
 		assert.equal(consumeSubagentExitSignal(sessionFile), null);
+	});
+
+	it("supersedes only existing error signals when requested", () => {
+		const dir = createTestDir();
+		const sessionFile = join(dir, "child.jsonl");
+		const exitFile = getSubagentExitSidecarPath(sessionFile);
+
+		for (const replacement of [
+			{ type: "done", outputTokens: 8 },
+			{ type: "ping", message: "help" },
+		]) {
+			writeFileSync(exitFile, JSON.stringify({ type: "error", errorMessage: "transient" }));
+			writeSubagentExitSidecar(sessionFile, replacement, { supersede: true });
+			assert.deepEqual(JSON.parse(readFileSync(exitFile, "utf8")), replacement);
+		}
+	});
+
+	it("never supersedes existing done or ping signals", () => {
+		const dir = createTestDir();
+		const sessionFile = join(dir, "child.jsonl");
+		const exitFile = getSubagentExitSidecarPath(sessionFile);
+
+		for (const existing of [{ type: "done" }, { type: "ping", message: "help" }]) {
+			writeFileSync(exitFile, JSON.stringify(existing));
+			writeSubagentExitSidecar(sessionFile, { type: "done", outputTokens: 8 }, { supersede: true });
+			assert.deepEqual(JSON.parse(readFileSync(exitFile, "utf8")), existing);
+		}
+	});
+
+	it("keeps first-write-wins behavior by default", () => {
+		const dir = createTestDir();
+		const sessionFile = join(dir, "child.jsonl");
+		const exitFile = getSubagentExitSidecarPath(sessionFile);
+		const error = { type: "error", errorMessage: "failure" };
+		writeFileSync(exitFile, JSON.stringify(error));
+
+		writeSubagentExitSidecar(sessionFile, { type: "done" });
+
+		assert.deepEqual(JSON.parse(readFileSync(exitFile, "utf8")), error);
 	});
 
 	it("clears stale sidecars before reusing a session path", () => {

--- a/test/session/session.test.ts
+++ b/test/session/session.test.ts
@@ -13,6 +13,7 @@ import {
 	copySessionFile,
 	findLastAssistantMessage,
 	findLastSubagentOutput,
+	findLastSubagentOutputWithSource,
 	getEntries,
 	getEntryCount,
 	getLeafId,
@@ -284,6 +285,26 @@ describe("session.ts", () => {
 			] as any[];
 
 			assert.equal(findLastSubagentOutput(entries), "Final assistant summary.");
+		});
+
+		it("marks synthesized terminal errors as runtime summaries", () => {
+			const terminalError = {
+				type: "message",
+				message: {
+					role: "assistant",
+					content: [],
+					stopReason: "error",
+					errorMessage: "Provider unavailable",
+				},
+			};
+
+			assert.deepEqual(
+				findLastSubagentOutputWithSource([terminalError] as any[]),
+				{
+					summary: "Subagent error: Provider unavailable",
+					summarySource: "runtime",
+				},
+			);
 		});
 
 		it("does not fall back to stale output after a terminal length stop", () => {

--- a/test/support/project.ts
+++ b/test/support/project.ts
@@ -117,6 +117,7 @@ export {
 	copySessionFile,
 	findLastAssistantMessage,
 	findLastSubagentOutput,
+	findLastSubagentOutputWithSource,
 	getEntries,
 	getEntryCount,
 	getLeafId,

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,3 +1,4 @@
+import "./auto-exit.test.ts";
 import "./session/session.test.ts";
 import "./session/child-session-storage.test.ts";
 import "./session/exit-sidecar.test.ts";

--- a/test/tools/subagent-done-recovery.test.ts
+++ b/test/tools/subagent-done-recovery.test.ts
@@ -186,7 +186,7 @@ describe("subagent-done.ts", () => {
 			}
 		});
 
-		it("fails permanent provider errors immediately without recovery nudges", async () => {
+		it("reports permanent provider errors on shutdown without recovery nudges", async () => {
 			const h = loadRecoveryChild();
 			try {
 				h.handlers.get("agent_end")?.(
@@ -194,6 +194,7 @@ describe("subagent-done.ts", () => {
 					h.ctx,
 				);
 				await sleep(20);
+				h.handlers.get("session_shutdown")?.();
 
 				const exit = JSON.parse(readFileSync(`${h.sessionFile}.exit`, "utf8"));
 				assert.equal(exit.type, "error");
@@ -205,7 +206,7 @@ describe("subagent-done.ts", () => {
 			}
 		});
 
-		it("cancels an armed recovery timer when a later permanent error fast-fails", () => {
+		it("cancels an armed recovery timer when a later permanent error requests shutdown", () => {
 			mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
 			const h = loadRecoveryChild();
 			try {
@@ -219,6 +220,7 @@ describe("subagent-done.ts", () => {
 				);
 
 				mock.timers.tick(10_000);
+				h.handlers.get("session_shutdown")?.();
 				const exit = JSON.parse(readFileSync(`${h.sessionFile}.exit`, "utf8"));
 				assert.equal(exit.type, "error");
 				assert.equal(exit.errorMessage, "insufficient_quota");


### PR DESCRIPTION
## What happened

A background child (an `analyst`-type agent, `pi -p`) hit a single transient Codex error mid-run:

> Codex error: An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists.

Pi's own retry recovered it. The child kept working and finished normally about 90 seconds later with a complete final report (`stopReason: "stop"` is the last message in its session file). But the parent's tool result said the run **failed** and that "The subagent did not produce a result", while the TUI widget rendered the full report right below the "failed" header. The parent model, believing its tool result, spawned a fresh wave of subagents to redo work that was already done.

<img width="2664" height="1522" alt="image" src="https://github.com/user-attachments/assets/8cd6c57d-5564-45f1-901c-414b7738e314" />

<img width="2664" height="1522" alt="log" src="https://github.com/user-attachments/assets/a653438f-e008-4f7d-b054-93909c2f20e3" />


Timeline from the child's session file:

| Time | Event |
|---|---|
| 23:08:20 | assistant message, `stopReason: "error"` (the Codex error above) |
| 23:08:21 to 23:09:44 | Pi retries, child continues, 10+ further tool calls |
| 23:09:49 | final assistant message, `stopReason: "stop"`, full report |
| exit | parent receives "failed... did not produce a result" |

## Findings

This may needs to be re-investigated, but here's the 4 findings that I found:

1. **The error string isn't classified.** "An error occurred while processing your request" matches neither `RETRYABLE_PROVIDER_ERROR_PATTERN` nor the non-retryable pattern in `auto-exit.ts`, so `findLatestAssistantError` returns `recoveryKind: "none"` and the error is treated as permanent, even though Pi retries this error routinely (and did, successfully).
2. **The failure is stamped while the child is still alive.** The `recoveryKind === "none"` branch in `subagent-done.ts` writes the `error` exit sidecar immediately at `agent_end` and requests shutdown. That races Pi's in-flight retry; in this run the child outlived the stamp by 89 seconds and completed.
3. **The sidecar is first-write-wins.** `writeExitSignal` refuses to write if the file exists, so the child's legitimate `done` at 23:09:49 was silently dropped. A premature error can never be corrected.
4. **The salvaged output never reaches the model.** `background-watch` correctly recovers the child's last real output into `summary`, but `wait-result.ts` / `result-router.ts` only place it in `details` (renderer-only) and tell the model "did not produce a result". Same pattern on the ping path: a `caller_ping` message goes to `details`, and the model-visible text is only "requested help and exited". That's why the human and the parent model see contradictory realities.

## Changes

- **`auto-exit.ts`**: added the generic Codex error string to the retryable pattern. Worst case for a genuinely fatal error misfiled as retryable: the existing 30/60/90s recovery ladder runs before giving up (about 3 minutes), and the failure is still reported. The worst case of the old misfiling was a discarded finished report, so the asymmetry favors retryable.
- **`subagent-done.ts`**: the `"none"` branch no longer writes the sidecar at `agent_end`. `pendingProviderError` is already set, and the existing `session_shutdown` handler reports it if the child actually dies. Shutdown is still requested; only the verdict is deferred.
- **`session/exit-sidecar.ts`** (write logic extracted from `subagent-done.ts`): `writeSubagentExitSidecar` gains a `supersede` option. Genuine completions (success-path `done`, `caller_ping`, `subagent_done`) may replace an existing `error` sidecar; nothing ever replaces a `done` or `ping`; the `session_shutdown` fallback and the recovery-exhausted kill keep first-write-wins.
- **`wait-result.ts` / `result-router.ts`**: when `hasRealSubagentOutput(summary)` (now exported from `runtime/state.ts`), the error delivery replaces the "did not produce a result" sentence with:

  ```
  Last output before the failure (may be incomplete — verify before trusting):

  <salvaged output>
  ```

  Otherwise the existing sentence stays. Ping deliveries now include the ping message in model-visible content. Header strings are unchanged, so `extractSummary`'s exact-match stripping in `message-renderers.ts` is unaffected.

Any one of the first three changes would have saved the traced run; the fourth also covers children that genuinely die mid-answer.

## Tests

Added coverage for the error classification, the sidecar supersede rules, and both delivery paths (salvaged output present or absent, ping message). Full suite: 501 pass, 1 fail, the fail being the pre-existing macOS `/var` to `/private/var` assertion in `herdr-interactive-launch.test.ts`, which fails on a clean checkout too.
