### PR TITLE
test: normalize macOS temporary paths

### DIFF
--- a/test/launch/herdr-interactive-launch.test.ts
+++ b/test/launch/herdr-interactive-launch.test.ts
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
-import { rmSync } from "node:fs";
+import { realpathSync, rmSync } from "node:fs";
 import {
 	ASSISTANT_MSG,
 	MODEL_CHANGE,
@@ -646,7 +646,9 @@ describe("Herdr interactive launch parity", () => {
 		assert.equal(running.mode, "background");
 		assert.equal(running.surface, undefined);
 		assert.equal(running.modelContextWindow, 2048);
-		assert.match(childLog, new RegExp(`PWD=${childCwd.replace(/'/g, "'\\''")}`));
+		const expectedChildCwd = realpathSync(childCwd);
+		const escapedChildCwd = expectedChildCwd.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		assert.match(childLog, new RegExp(`PWD=${escapedChildCwd}`));
 		assert.match(childLog, /CUSTOM_ENV=from-background-agent/);
 		assert.match(childLog, /SURFACE=\n/);
 		assert.match(childLog, /--no-approve/);


### PR DESCRIPTION
## Summary

Make the background-launch path assertion portable across macOS installations that expose temporary directories as either `/var/...` or `/private/var/...`.

## Change

Resolve the expected child working directory with `realpathSync` and escape it before constructing the assertion regex. This is test-only and does not alter launch behavior.

## Validation

- TypeScript compilation passes.
- The focused Herdr interactive-launch test passes in the normal source checkout.
- The full suite was previously green after this fix in the normal checkout.
