### PR TITLE
fix(agents): render interactive manual-lifecycle agents truthfully in roster

### DIFF
--- a/src/agents/agent-list.ts
+++ b/src/agents/agent-list.ts
@@ -78,7 +78,14 @@ function getContext(entry: AgentListEntry): "fresh_chat_needs_full_brief" | "cop
 }
 
 function getCompletion(entry: AgentListEntry): "exits_automatically" | "human_or_agent_must_finish" {
-	return entry.autoExit === false ? "human_or_agent_must_finish" : "exits_automatically";
+	if (entry.autoExit === true) return "exits_automatically";
+	if (entry.autoExit === false) return "human_or_agent_must_finish";
+	// Undefined `auto-exit` resolves to manual lifecycle at launch: interactive
+	// children are told to stay open for the operator and never receive
+	// `subagent_done`, so their result only arrives once a human (or
+	// subagent_kill) closes the pane. Background children must call
+	// `subagent_done` themselves and keep the exits_automatically contract.
+	return entry.mode === "background" ? "exits_automatically" : "human_or_agent_must_finish";
 }
 
 function renderDefaultModelLine(entry: AgentListEntry): string | undefined {

--- a/test/agents/definitions-agent-list.test.ts
+++ b/test/agents/definitions-agent-list.test.ts
@@ -396,6 +396,42 @@ describe("agent definitions and catalog", () => {
 		assert.match(reminder, /no `models:` line ignores model and thinking overrides/);
 	});
 
+	it("renders the completion contract to match each child's actual exit path", () => {
+		const dir = createTestDir();
+		const configDir = join(dir, "agent-root");
+		const agentsDir = join(configDir, "agents");
+		mkdirSync(agentsDir, { recursive: true });
+		process.env.PI_CODING_AGENT_DIR = configDir;
+
+		writeFileSync(
+			join(agentsDir, "pairing.md"),
+			`---\nname: pairing\ndescription: Interactive agent without auto-exit\nmode: interactive\n---\n\nBody.`,
+		);
+		writeFileSync(
+			join(agentsDir, "fire-and-forget.md"),
+			`---\nname: fire-and-forget\ndescription: Interactive agent with auto-exit\nmode: interactive\nauto-exit: true\n---\n\nBody.`,
+		);
+		writeFileSync(
+			join(agentsDir, "runner.md"),
+			`---\nname: runner\ndescription: Background agent without auto-exit\nmode: background\n---\n\nBody.`,
+		);
+		writeFileSync(
+			join(agentsDir, "pinned-open.md"),
+			`---\nname: pinned-open\ndescription: Background agent with explicit auto-exit false\nmode: background\nauto-exit: false\n---\n\nBody.`,
+		);
+
+		const reminder = renderAgentListReminderForTest(getAgentListEntriesForTest(dir));
+		// Interactive children without `auto-exit` are told to stay open for the
+		// operator and never receive `subagent_done`, so their results only
+		// arrive after the pane is closed. The roster must not promise otherwise.
+		assert.match(reminder, /`pairing`[\s\S]*?completion: human_or_agent_must_finish/);
+		assert.match(reminder, /`fire-and-forget`[\s\S]*?completion: exits_automatically/);
+		// Background children must call `subagent_done` themselves, so the
+		// default contract stays exits_automatically for them.
+		assert.match(reminder, /`runner`[\s\S]*?completion: exits_automatically/);
+		assert.match(reminder, /`pinned-open`[\s\S]*?completion: human_or_agent_must_finish/);
+	});
+
 	it("defaults spawning to false for named agent definitions", () => {
 		const dir = createTestDir();
 		const configDir = join(dir, "agent-root");

--- a/test/agents/definitions-agent-list.test.ts
+++ b/test/agents/definitions-agent-list.test.ts
@@ -419,17 +419,28 @@ describe("agent definitions and catalog", () => {
 			join(agentsDir, "pinned-open.md"),
 			`---\nname: pinned-open\ndescription: Background agent with explicit auto-exit false\nmode: background\nauto-exit: false\n---\n\nBody.`,
 		);
+		writeFileSync(
+			join(agentsDir, "no-mode.md"),
+			`---\nname: no-mode\ndescription: Agent with no mode field\n---\n\nBody.`,
+		);
 
 		const reminder = renderAgentListReminderForTest(getAgentListEntriesForTest(dir));
+		// Bound each assertion to one agent block. Unbounded `[\s\S]*?` regexes
+		// matched across the blank-line block boundary into the next agent's
+		// completion line, so they passed even against the old renderer.
+		const blockFor = (name: string) =>
+			reminder.match(new RegExp(`^- \`${name}\`:[\\s\\S]*?(?=\\n\\n|\\n</subagent-roster>)`, "m"))?.[0] ?? "";
 		// Interactive children without `auto-exit` are told to stay open for the
 		// operator and never receive `subagent_done`, so their results only
 		// arrive after the pane is closed. The roster must not promise otherwise.
-		assert.match(reminder, /`pairing`[\s\S]*?completion: human_or_agent_must_finish/);
-		assert.match(reminder, /`fire-and-forget`[\s\S]*?completion: exits_automatically/);
+		// An omitted `mode` takes the interactive launch path as well.
+		assert.match(blockFor("pairing"), /completion: human_or_agent_must_finish/);
+		assert.match(blockFor("no-mode"), /completion: human_or_agent_must_finish/);
+		assert.match(blockFor("fire-and-forget"), /completion: exits_automatically/);
 		// Background children must call `subagent_done` themselves, so the
 		// default contract stays exits_automatically for them.
-		assert.match(reminder, /`runner`[\s\S]*?completion: exits_automatically/);
-		assert.match(reminder, /`pinned-open`[\s\S]*?completion: human_or_agent_must_finish/);
+		assert.match(blockFor("runner"), /completion: exits_automatically/);
+		assert.match(blockFor("pinned-open"), /completion: human_or_agent_must_finish/);
 	});
 
 	it("defaults spawning to false for named agent definitions", () => {


### PR DESCRIPTION
## Problem

When a parent launches an **interactive** (visible-terminal) agent that does not set `auto-exit: true`, the subagent finishes its task and then waits forever, and the parent never receives the result. Operators have to notice the idle child pane, tell the parent it finished, and have the parent manually harvest the child session file before killing the pane.

## Root cause

Two parts of the codebase disagree about what *undefined* `auto-exit` means:

- **Roster** (`src/agents/agent-list.ts`): `getCompletion()` rendered `completion: exits_automatically` whenever `autoExit !== false` — i.e. also for `undefined`.
- **Launch** (`src/launch/interactive.ts`): `autoExit: prepared.agentDefs?.autoExit ?? false` — `undefined` resolves to manual lifecycle. The child's prompt is built with:

  > "Manual lifecycle: the operator must close this foreground pane when done. Stay in this pane and wait for the operator to interact with you. **Do not exit on your own.**"

  …and `shouldRegisterSubagentDone` never registers `subagent_done` for interactive children.

So for interactive + undefined `auto-exit`, the child is *instructed* to stay open, while the parent is told (both by the roster and by the launch tool result: *"Results will be delivered automatically as a steer message when it finishes"*) that the result will arrive on its own. It cannot: the watcher only resolves when the child process exits, the exit sidecar is written, or the done sentinel appears — none of which happen until a human closes the pane.

This matches the README (`auto-exit` default is documented as `false`) — the launch behavior is intended; the roster line is the bug.

## Evidence

From a real session (parent TUI under tmux, interactive children without `auto-exit`):

| child | task finished | exit signal written | steer delivered |
|---|---|---|---|
| vision-describer v4 | 05:40:26 | 05:49:09 (pane closed manually) | 05:49:09 — same instant the child finally exited |
| 4 other children | on time | never (panes stayed open) | never — parent had to be nudged, then read the child session file manually |

The delivery machinery itself is fine: every time a child *did* exit (including kills), the steer arrived within ~1s. The missing piece was always the child never exiting.

## Fix

`getCompletion()` now renders the contract that matches the real exit path:

| frontmatter | mode | roster says |
|---|---|---|
| `auto-exit: true` | any | `exits_automatically` (unchanged) |
| `auto-exit: false` | any | `human_or_agent_must_finish` (unchanged) |
| undefined | background | `exits_automatically` (unchanged — background children must call `subagent_done`) |
| undefined | interactive | `human_or_agent_must_finish` (**fixed**) |

## Validation

- `tsc --noEmit` clean; full `npm test` suite passes (624 pass, 0 fail).
- New unit test covers all four combinations.
- Live check: a fresh parent session with interactive agents lacking `auto-exit` now renders `completion: human_or_agent_must_finish` in the roster.
- Live e2e with `auto-exit: true` added to the agent: the child exits on completion and its report is delivered (verified via session JSONL).

## Possible follow-ups (not in this PR)

- The async launch tool result unconditionally promises "Results will be delivered automatically as a steer message when it finishes" — for manual-lifecycle children it could instead say the result arrives once the pane is closed (`subagent_kill` or operator close).
- `subagent_kill` on a finished-but-still-open child currently reports only "Subagent cancelled."; it could harvest the child's final assistant message as the result summary (it already does this on other paths via `findLastSubagentOutputWithSource`).