### PR TITLE
fix(mux): run staged launch scripts in Windows PowerShell and cmd panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ The backend command must exist, and Pi must be able to see the current pane or s
 
 Normal launches use a backend-specific surface. Herdr keeps children beside the parent while the tab has room, then uses dedicated tabs for overflow. Every Herdr child pane is labeled with its session title, such as `[reviewer] Auth implementation review`. Other backends may use windows, splits, or stacked panes.
 
+### Windows panes
+
+Interactive launches are staged as a POSIX script and typed into the child pane. On Windows that
+pane usually runs PowerShell, which prints a bare quoted path instead of executing it, so Pi invokes
+the staged script through `bash.exe` there. Pi asks Herdr for the pane process and picks the syntax
+from it, so a Herdr `default_shell` of bash still gets the plain POSIX line. Detection reads the
+pane's own shell; Pi falls back to the platform default when Herdr cannot report it.
+
+Pi looks for the interpreter in this order: `PI_SUBAGENT_WIN_BASH`, then `bash` on `PATH`, then the
+usual Git for Windows and MSYS2 install roots. WSL's `C:\Windows\System32\bash.exe` is skipped: it
+cannot open Windows paths or launch a Windows Pi. Set `PI_SUBAGENT_WIN_BASH` when the `bash` on your
+`PATH` is a Cygwin build, which resolves Windows paths differently. When no interpreter is found,
+the launch fails with a setup error instead of leaving a pane that never starts an agent.
+
 ### Orchestrator mode
 
 You can turn the parent session into an orchestrator — an agent that can only
@@ -881,6 +895,7 @@ User-facing knobs:
 | `PI_ORCHESTRATOR_MODE` | Set `1` to turn the parent into an orchestrator (delegation-only tools, replacement system prompt) |
 | `PI_SUBAGENT_PI_COMMAND` | Launch children through a wrapper command |
 | `PI_SUBAGENT_MUX` | Force `herdr`, `cmux`, `tmux`, `zellij`, or `wezterm` |
+| `PI_SUBAGENT_WIN_BASH` | Windows only: path to the `bash.exe` that runs staged launch scripts in a PowerShell or cmd pane |
 | `PI_CODING_AGENT_DIR` | Use a different Pi agent config root |
 | `PI_SUBAGENT_DISABLE_COORDINATOR_ONLY_TURN` | Set `1` to let the parent keep running after async launches |
 | `PI_SUBAGENT_DISABLE_CHILD_CONTEXT_BOUNDARY` | Set `1` for raw forks with no boundary marker |

--- a/src/launch/background.ts
+++ b/src/launch/background.ts
@@ -149,6 +149,7 @@ export async function launchBackgroundSubagent(
 	const child = spawn(invocation.command, invocation.args, {
 		cwd: launch.forcedCwd ?? prepared.runtimePaths.effectiveCwd ?? ctx.cwd,
 		detached: true,
+		windowsHide: true,
 		stdio:
 			resolveSubagentParentClosePolicy(prepared.agentDefs) === "continue"
 				? ["ignore", "ignore", "ignore"]

--- a/src/mux/herdr.ts
+++ b/src/mux/herdr.ts
@@ -434,6 +434,32 @@ export function splitHerdrPane(options: {
 	return parseCreatedPane(result, "pane split");
 }
 
+// Best-effort: the pane shell decides whether a staged POSIX script can be typed as-is.
+// Older Herdr builds may not expose process-info, so every failure degrades to an empty
+// list and the caller falls back to the platform default.
+// On an idle pane the foreground process is the pane's own shell, which is the state a
+// launch targets. A busy pane can report the program it is running instead (`node.exe`),
+// so callers classify the reported names and fall back when none of them is a known shell.
+// A shell started by hand inside the pane is not reported separately on Windows, because
+// ConPTY exposes a single foreground process group.
+export function getHerdrPaneProcessNames(paneId: string): string[] {
+	try {
+		const result = runHerdrApi("pane process-info", ["pane", "process-info", "--pane", paneId]);
+		const info = isRecord(result.process_info) ? result.process_info : undefined;
+		if (!info) return [];
+		const processes = Array.isArray(info.foreground_processes) ? info.foreground_processes : [];
+		const names: string[] = [];
+		for (const entry of processes) {
+			if (!isRecord(entry)) continue;
+			const name = stringField(entry, "name") ?? stringField(entry, "argv0");
+			if (name) names.push(name);
+		}
+		return names;
+	} catch {
+		return [];
+	}
+}
+
 export function runHerdrPaneCommand(paneId: string, command: string): void {
 	runHerdrVoid("pane run", ["pane", "run", paneId, command]);
 }

--- a/src/mux/io.ts
+++ b/src/mux/io.ts
@@ -13,11 +13,13 @@ import {
 } from "./core.ts";
 import {
 	closeHerdrPane,
+	getHerdrPaneProcessNames,
 	readHerdrPaneScreen,
 	readHerdrPaneScreenAsync,
 	runHerdrPaneCommand,
 	sendHerdrPaneEnter,
 } from "./herdr.ts";
+import { buildStagedShellCommand, resolveStagedShellPlan } from "./staged-shell.ts";
 import { closeZellijSurface } from "./zellij-runtime.ts";
 
 export function sendCommand(surface: string, command: string): void {
@@ -72,8 +74,9 @@ function stageShellCommand(command: string): string {
 	return scriptPath;
 }
 
-function buildStagedShellCommand(scriptPath: string): string {
-	return `${shellEscape(scriptPath)}; rm -f ${shellEscape(scriptPath)}`;
+// Only Herdr can report the pane process today; cmux falls back to the platform default.
+function paneShellNames(backend: string, surface: string): string[] {
+	return backend === "herdr" ? getHerdrPaneProcessNames(surface) : [];
 }
 
 export function sendShellCommand(surface: string, command: string): void {
@@ -82,9 +85,12 @@ export function sendShellCommand(surface: string, command: string): void {
 		sendCommand(surface, command);
 		return;
 	}
+	// Resolved before staging: a missing interpreter must fail loudly instead of
+	// leaving an orphaned %TEMP% script and a pane that never starts an agent.
+	const plan = resolveStagedShellPlan(paneShellNames(backend, surface));
 	const scriptPath = stageShellCommand(command);
 	try {
-		sendCommand(surface, buildStagedShellCommand(scriptPath));
+		sendCommand(surface, buildStagedShellCommand(scriptPath, plan));
 	} catch (error) {
 		try {
 			rmSync(scriptPath, { force: true });

--- a/src/mux/staged-shell.ts
+++ b/src/mux/staged-shell.ts
@@ -1,0 +1,167 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { shellEscape } from "./core.ts";
+
+// Interactive launches are staged as a POSIX script and typed into the child pane.
+// The pane shell is not always POSIX: on Windows a Herdr or cmux pane usually runs
+// PowerShell, which prints a bare quoted path instead of executing it and rejects
+// `rm -f` ("the parameter name 'f' is ambiguous"). Both halves of the staged line
+// fail silently, so the parent waits forever on a done sentinel that is never written.
+// This module classifies the pane shell and emits a line that shell can actually run.
+
+export type PaneShellKind = "posix" | "powershell" | "cmd";
+
+const POSIX_SHELL_NAMES = new Set(["sh", "bash", "dash", "zsh", "ksh", "fish", "busybox", "ash"]);
+const POWERSHELL_NAMES = new Set(["pwsh", "powershell"]);
+const CMD_NAMES = new Set(["cmd"]);
+
+export function classifyPaneShell(processName: string | undefined): PaneShellKind | undefined {
+	if (!processName) return undefined;
+	const base = processName.split(/[\\/]/).pop() ?? "";
+	const name = base.trim().toLowerCase().replace(/\.exe$/, "");
+	if (!name) return undefined;
+	if (POWERSHELL_NAMES.has(name)) return "powershell";
+	if (CMD_NAMES.has(name)) return "cmd";
+	if (POSIX_SHELL_NAMES.has(name)) return "posix";
+	return undefined;
+}
+
+// A pane can report several foreground processes, and a busy one can report a program
+// rather than its shell. Take the first name that is a shell we recognize.
+export function classifyPaneShells(processNames: readonly string[]): PaneShellKind | undefined {
+	for (const name of processNames) {
+		const kind = classifyPaneShell(name);
+		if (kind) return kind;
+	}
+	return undefined;
+}
+
+// Used when the backend cannot report the pane process. Windows panes default to
+// PowerShell because that is the Herdr and cmux default shell there.
+export function defaultPaneShellKind(platform: NodeJS.Platform = process.platform): PaneShellKind {
+	return platform === "win32" ? "powershell" : "posix";
+}
+
+function psQuote(value: string): string {
+	return `'${value.replace(/'/g, "''")}'`;
+}
+
+function cmdQuote(value: string): string {
+	return `"${value.replace(/"/g, '""')}"`;
+}
+
+export type PosixInterpreterProbe = {
+	getEnv?: (name: string) => string | undefined;
+	exists?: (path: string) => boolean;
+	whichAll?: (command: string) => string[];
+};
+
+// WSL ships C:\Windows\System32\bash.exe and it often wins `where bash`. It runs in the
+// Linux filesystem namespace, so `cd 'C:\...'` fails and `pi` resolves to a Linux binary
+// or nothing at all. It can never launch a Windows subagent; skip it explicitly.
+export function isWslBashPath(candidate: string): boolean {
+	const normalized = candidate.replace(/\//g, "\\").toLowerCase();
+	return /\\windows\\(system32|sysnative|syswow64)\\bash\.exe$/.test(normalized);
+}
+
+function windowsBashCandidates(getEnv: (name: string) => string | undefined): string[] {
+	const roots = [getEnv("ProgramFiles"), getEnv("ProgramFiles(x86)"), getEnv("ProgramW6432")].filter(
+		(root): root is string => !!root,
+	);
+	const local = getEnv("LOCALAPPDATA");
+	const candidates: string[] = [];
+	for (const root of roots) {
+		candidates.push(`${root}\\Git\\usr\\bin\\bash.exe`, `${root}\\Git\\bin\\bash.exe`);
+	}
+	if (local) {
+		candidates.push(`${local}\\Programs\\Git\\usr\\bin\\bash.exe`, `${local}\\Programs\\Git\\bin\\bash.exe`);
+	}
+	// MSYS2 only. Cygwin's bash is deliberately not listed: its path layer does not
+	// accept a Windows `cd 'C:\...'` the way Git for Windows and MSYS2 do.
+	candidates.push("C:\\msys64\\usr\\bin\\bash.exe");
+	return candidates;
+}
+
+function whereCommand(command: string): string[] {
+	try {
+		const output = execFileSync("where.exe", [command], { encoding: "utf8" });
+		return output
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0);
+	} catch {
+		return [];
+	}
+}
+
+// Resolution order: explicit override, then PATH (minus WSL), then known install roots.
+export function resolveWindowsPosixInterpreter(probe: PosixInterpreterProbe = {}): string | undefined {
+	const getEnv = probe.getEnv ?? DEFAULT_ENV_READER;
+	const exists = probe.exists ?? existsSync;
+	const whichAll = probe.whichAll ?? whereCommand;
+
+	const explicit = (getEnv("PI_SUBAGENT_WIN_BASH") ?? "").trim();
+	if (explicit) return exists(explicit) ? explicit : undefined;
+
+	for (const candidate of whichAll("bash")) {
+		if (isWslBashPath(candidate)) continue;
+		if (exists(candidate)) return candidate;
+	}
+	for (const candidate of windowsBashCandidates(getEnv)) {
+		if (exists(candidate)) return candidate;
+	}
+	return undefined;
+}
+
+const DEFAULT_ENV_READER = (name: string) => process.env[name];
+
+export function posixInterpreterSetupHint(getEnv = DEFAULT_ENV_READER): string {
+	const explicit = (getEnv("PI_SUBAGENT_WIN_BASH") ?? "").trim();
+	if (explicit) {
+		return (
+			`PI_SUBAGENT_WIN_BASH points at "${explicit}", which does not exist. ` +
+			'Set it to a bash.exe that can run Windows paths, for example "C:\\Program Files\\Git\\usr\\bin\\bash.exe".'
+		);
+	}
+	return (
+		"No POSIX shell was found to run the staged subagent launch script in this pane. " +
+		"Install Git for Windows, or set PI_SUBAGENT_WIN_BASH to a bash.exe path. " +
+		"WSL's C:\\Windows\\System32\\bash.exe is ignored: it cannot open Windows paths or launch a Windows pi."
+	);
+}
+
+export type StagedShellPlan = {
+	kind: PaneShellKind;
+	interpreter?: string;
+};
+
+export function buildStagedShellCommand(scriptPath: string, plan: StagedShellPlan): string {
+	if (plan.kind === "posix") {
+		return `${shellEscape(scriptPath)}; rm -f ${shellEscape(scriptPath)}`;
+	}
+	if (!plan.interpreter) {
+		throw new Error(`Staged ${plan.kind} launch requires a POSIX interpreter. ${posixInterpreterSetupHint()}`);
+	}
+	if (plan.kind === "powershell") {
+		// `&` is required: PowerShell evaluates a bare quoted path as a string literal.
+		return `& ${psQuote(plan.interpreter)} ${psQuote(scriptPath)}; Remove-Item -Force ${psQuote(scriptPath)}`;
+	}
+	return `${cmdQuote(plan.interpreter)} ${cmdQuote(scriptPath)} & del /f /q ${cmdQuote(scriptPath)}`;
+}
+
+// Resolve before staging so a missing interpreter fails loudly instead of leaving an
+// orphaned %TEMP% script and a child pane that never starts.
+export function resolveStagedShellPlan(
+	paneShellNames: readonly string[],
+	probe: PosixInterpreterProbe = {},
+	platform: NodeJS.Platform = process.platform,
+): StagedShellPlan {
+	const kind = classifyPaneShells(paneShellNames) ?? defaultPaneShellKind(platform);
+	if (kind === "posix") return { kind };
+	const interpreter = resolveWindowsPosixInterpreter(probe);
+	if (!interpreter) {
+		const getEnv = probe.getEnv ?? DEFAULT_ENV_READER;
+		throw new Error(`Cannot start an interactive subagent in this pane. ${posixInterpreterSetupHint(getEnv)}`);
+	}
+	return { kind, interpreter };
+}

--- a/src/runtime/resume-service.ts
+++ b/src/runtime/resume-service.ts
@@ -465,6 +465,7 @@ async function resumeSubagentSessionWithoutWidth(
 		const child = spawn(invocation.command, invocation.args, {
 			...(resumeCwd ? { cwd: resumeCwd } : {}),
 			detached: true,
+			windowsHide: true,
 			stdio:
 				running.parentClosePolicy === "continue"
 					? (["pipe", "ignore", "ignore"] as const)

--- a/src/runtime/timeout-wrap-up.ts
+++ b/src/runtime/timeout-wrap-up.ts
@@ -167,6 +167,7 @@ export async function restartSubagentForTimeoutWrapUp(
 		const child = spawn(invocation.command, invocation.args, {
 			...(launch.cwd ? { cwd: launch.cwd } : {}),
 			detached: true,
+			windowsHide: true,
 			stdio:
 				running.parentClosePolicy === "continue"
 					? (["pipe", "ignore", "ignore"] as const)

--- a/test/mux/staged-shell.test.ts
+++ b/test/mux/staged-shell.test.ts
@@ -1,0 +1,183 @@
+import {
+	buildStagedShellCommand,
+	classifyPaneShell,
+	classifyPaneShells,
+	defaultPaneShellKind,
+	isWslBashPath,
+	posixInterpreterSetupHint,
+	resolveStagedShellPlan,
+	resolveWindowsPosixInterpreter,
+} from "../../src/mux/staged-shell.ts";
+import { assert, describe, it } from "../support/index.ts";
+
+const GIT_BASH = "C:\\Program Files\\Git\\usr\\bin\\bash.exe";
+const WSL_BASH = "C:\\Windows\\System32\\bash.exe";
+
+function probe(options: {
+	env?: Record<string, string | undefined>;
+	present?: string[];
+	which?: string[];
+}) {
+	const env = options.env ?? {};
+	const present = new Set((options.present ?? []).map((entry) => entry.toLowerCase()));
+	return {
+		getEnv: (name: string) => env[name],
+		exists: (path: string) => present.has(path.toLowerCase()),
+		whichAll: () => options.which ?? [],
+	};
+}
+
+describe("staged shell pane classification", () => {
+	it("classifies PowerShell, cmd, and POSIX pane processes by executable name", () => {
+		assert.equal(classifyPaneShell("C:\\Users\\me\\AppData\\Local\\Microsoft\\WindowsApps\\pwsh.exe"), "powershell");
+		assert.equal(classifyPaneShell("powershell.EXE"), "powershell");
+		assert.equal(classifyPaneShell("cmd.exe"), "cmd");
+		assert.equal(classifyPaneShell("C:\\Program Files\\Git\\usr\\bin\\bash.exe"), "posix");
+		assert.equal(classifyPaneShell("/bin/zsh"), "posix");
+		assert.equal(classifyPaneShell("fish"), "posix");
+	});
+
+	it("returns undefined for unknown or empty process names", () => {
+		assert.equal(classifyPaneShell(undefined), undefined);
+		assert.equal(classifyPaneShell(""), undefined);
+		assert.equal(classifyPaneShell("node.exe"), undefined);
+	});
+
+	it("takes the first recognized shell when a busy pane also reports a program", () => {
+		assert.equal(classifyPaneShells(["node.exe", "pwsh.exe"]), "powershell");
+		assert.equal(classifyPaneShells(["node.exe"]), undefined);
+		assert.equal(classifyPaneShells([]), undefined);
+	});
+
+	it("defaults to PowerShell on win32 and POSIX elsewhere", () => {
+		assert.equal(defaultPaneShellKind("win32"), "powershell");
+		assert.equal(defaultPaneShellKind("linux"), "posix");
+		assert.equal(defaultPaneShellKind("darwin"), "posix");
+	});
+});
+
+describe("staged shell command construction", () => {
+	it("keeps the POSIX line unchanged for POSIX panes", () => {
+		assert.equal(
+			buildStagedShellCommand("/tmp/pi-subagent-shell-1.sh", { kind: "posix" }),
+			"'/tmp/pi-subagent-shell-1.sh'; rm -f '/tmp/pi-subagent-shell-1.sh'",
+		);
+	});
+
+	it("invokes the interpreter through the PowerShell call operator and deletes with Remove-Item", () => {
+		const command = buildStagedShellCommand("C:\\Temp\\pi-subagent-shell-1.sh", {
+			kind: "powershell",
+			interpreter: GIT_BASH,
+		});
+		assert.equal(
+			command,
+			`& '${GIT_BASH}' 'C:\\Temp\\pi-subagent-shell-1.sh'; Remove-Item -Force 'C:\\Temp\\pi-subagent-shell-1.sh'`,
+		);
+		assert.ok(command.startsWith("& "), "a bare quoted path is a string literal in PowerShell");
+		assert.ok(!command.includes("rm -f"), "rm -f resolves to Remove-Item, whose -f is ambiguous");
+	});
+
+	it("escapes single quotes in PowerShell paths by doubling them", () => {
+		const command = buildStagedShellCommand("C:\\Temp\\it's\\script.sh", {
+			kind: "powershell",
+			interpreter: GIT_BASH,
+		});
+		assert.ok(command.includes("'C:\\Temp\\it''s\\script.sh'"));
+	});
+
+	it("uses double quotes and del for cmd panes", () => {
+		assert.equal(
+			buildStagedShellCommand("C:\\Temp\\script.sh", { kind: "cmd", interpreter: GIT_BASH }),
+			`"${GIT_BASH}" "C:\\Temp\\script.sh" & del /f /q "C:\\Temp\\script.sh"`,
+		);
+	});
+
+	it("refuses to build a non-POSIX line without an interpreter", () => {
+		assert.throws(() => buildStagedShellCommand("C:\\Temp\\script.sh", { kind: "powershell" }), /POSIX interpreter/);
+	});
+});
+
+describe("windows POSIX interpreter resolution", () => {
+	it("prefers PI_SUBAGENT_WIN_BASH when it exists", () => {
+		const custom = "D:\\tools\\bash.exe";
+		assert.equal(
+			resolveWindowsPosixInterpreter(
+				probe({ env: { PI_SUBAGENT_WIN_BASH: custom }, present: [custom, GIT_BASH], which: [GIT_BASH] }),
+			),
+			custom,
+		);
+	});
+
+	it("does not silently fall back when PI_SUBAGENT_WIN_BASH is wrong", () => {
+		assert.equal(
+			resolveWindowsPosixInterpreter(
+				probe({ env: { PI_SUBAGENT_WIN_BASH: "D:\\missing\\bash.exe" }, present: [GIT_BASH], which: [GIT_BASH] }),
+			),
+			undefined,
+		);
+	});
+
+	it("skips WSL bash on PATH and takes the next real POSIX shell", () => {
+		assert.ok(isWslBashPath(WSL_BASH));
+		assert.ok(isWslBashPath("C:/Windows/Sysnative/bash.exe"));
+		assert.ok(!isWslBashPath(GIT_BASH));
+		assert.equal(
+			resolveWindowsPosixInterpreter(probe({ present: [WSL_BASH, GIT_BASH], which: [WSL_BASH, GIT_BASH] })),
+			GIT_BASH,
+		);
+	});
+
+	it("falls back to known install roots when PATH has no usable bash", () => {
+		assert.equal(
+			resolveWindowsPosixInterpreter(
+				probe({ env: { ProgramFiles: "C:\\Program Files" }, present: [GIT_BASH], which: [WSL_BASH] }),
+			),
+			GIT_BASH,
+		);
+		assert.equal(
+			resolveWindowsPosixInterpreter(
+				probe({
+					env: { LOCALAPPDATA: "C:\\Users\\me\\AppData\\Local" },
+					present: ["C:\\Users\\me\\AppData\\Local\\Programs\\Git\\usr\\bin\\bash.exe"],
+				}),
+			),
+			"C:\\Users\\me\\AppData\\Local\\Programs\\Git\\usr\\bin\\bash.exe",
+		);
+	});
+
+	it("returns undefined when nothing usable exists", () => {
+		assert.equal(resolveWindowsPosixInterpreter(probe({ which: [WSL_BASH], present: [WSL_BASH] })), undefined);
+	});
+});
+
+describe("staged shell plan", () => {
+	it("uses the reported pane shell over the platform default", () => {
+		const plan = resolveStagedShellPlan(["bash.exe"], probe({ present: [GIT_BASH], which: [GIT_BASH] }), "win32");
+		assert.deepEqual(plan, { kind: "posix" });
+	});
+
+	it("plans a PowerShell launch for a pwsh pane", () => {
+		const plan = resolveStagedShellPlan(["pwsh.exe"], probe({ present: [GIT_BASH], which: [GIT_BASH] }), "win32");
+		assert.deepEqual(plan, { kind: "powershell", interpreter: GIT_BASH });
+	});
+
+	it("falls back to the platform default when the pane reports no known shell", () => {
+		const plan = resolveStagedShellPlan(["node.exe"], probe({ present: [GIT_BASH], which: [GIT_BASH] }), "win32");
+		assert.equal(plan.kind, "powershell");
+		assert.deepEqual(resolveStagedShellPlan([], probe({}), "linux"), { kind: "posix" });
+	});
+
+	it("fails loudly instead of staging a script no shell can run", () => {
+		assert.throws(
+			() => resolveStagedShellPlan(["pwsh.exe"], probe({ which: [WSL_BASH], present: [WSL_BASH] }), "win32"),
+			/PI_SUBAGENT_WIN_BASH/,
+		);
+	});
+
+	it("names the bad override in the hint when one is set", () => {
+		const hint = posixInterpreterSetupHint((name) =>
+			name === "PI_SUBAGENT_WIN_BASH" ? "D:\\missing\\bash.exe" : undefined,
+		);
+		assert.ok(hint.includes("D:\\missing\\bash.exe"));
+	});
+});

--- a/test/test.ts
+++ b/test/test.ts
@@ -78,6 +78,7 @@ import "./mux/poll.test.ts";
 import "./mux/herdr.test.ts";
 import "./mux/herdr-placement.test.ts";
 import "./mux/runtime-probe.test.ts";
+import "./mux/staged-shell.test.ts";
 import "./mux/zellij-placement.test.ts";
 import "./mux/zellij-owned-placement.test.ts";
 import "./agents/roster-filtering.test.ts";


### PR DESCRIPTION
## The bug

Every interactive subagent launch hangs forever on Windows.

`sendShellCommand` stages the launch as a POSIX script in `%TEMP%` and types this into the freshly created child pane:

```
'<path>.sh'; rm -f '<path>.sh'
```

On Windows that pane runs PowerShell (the Herdr and cmux default shell there). PowerShell evaluates a bare quoted path as a *string literal* — it prints the path and never executes it — and `rm` resolves to `Remove-Item`, whose `-f` is ambiguous between `-Filter` and `-Force`:

```
C:\Users\...\AppData\Local\Temp\pi-subagent-shell-1786957695631-v06lbzp05ct.sh
Remove-Item: Parameter cannot be processed because the parameter name 'f' is ambiguous.
Possible matches include: -Filter -Force.
```

Both halves fail, and nothing reports it. No child process is created, the staged script is orphaned, and the parent blocks forever polling for a done-sentinel that is never written. From the user's side the launch just sits at `thinking…`.

Observed on a real setup: 17 orphaned `%TEMP%\pi-subagent-shell-*.sh` files and a correctly labelled but completely dead `[scout] …` Herdr pane.

Everything else in the launch path works — Herdr detection, `pane split`, cwd, pane labelling. Only the typed command is wrong for the shell receiving it.

## The fix

Ask Herdr for the pane process instead of guessing from the platform, then emit a line that shell can actually run:

| pane shell | emitted |
| --- | --- |
| pwsh / powershell | `& '<bash>' '<script>'; Remove-Item -Force '<script>'` |
| cmd | `"<bash>" "<script>" & del /f /q "<script>"` |
| POSIX | unchanged, byte for byte |

Notes on the details:

- **A Herdr `default_shell` of bash still gets the POSIX line.** The choice is driven by `herdr pane process-info`, not by `process.platform`, so this does not force PowerShell syntax on a Windows user who runs bash panes.
- **A busy pane can report the program it is running** (`node.exe`) rather than its shell, so the reported foreground processes are classified in order and an unrecognized set falls back to the platform default: PowerShell on win32, POSIX elsewhere. cmux has no equivalent probe and always uses that default.
- **Interpreter resolution:** `PI_SUBAGENT_WIN_BASH` → `bash` on `PATH` → the usual Git for Windows and MSYS2 roots. WSL's `C:\Windows\System32\bash.exe` is skipped deliberately: it runs in the Linux filesystem namespace, so `cd 'C:\...'` fails and `pi` does not resolve to the Windows install — and it frequently wins `where bash`. Cygwin is not in the candidate list for the same class of reason, and the README points Cygwin users at the env var.
- **It fails loudly.** Resolution happens *before* the script is written, so a machine with no usable interpreter raises a setup error instead of reproducing the original symptom (hang + orphaned temp file). Arguably this matters more than the syntax fix: the old failure mode was invisible.

Command generation stays POSIX. Only the invocation changes, so the exit trap, `cd … &&` prefix, `VAR=value` env prefix and `$?` sentinel shared by the interactive, resume and timeout-wrap-up launch paths are untouched.

## Why not generate PowerShell instead

The staged command is irreducibly POSIX today — `trap '<sentinel>' EXIT; cd '<cwd>' && VAR=v pi …; <sentinel>` — and the same shape is built in three places (`launch/interactive.ts`, `runtime/resume-service.ts`, `runtime/timeout-wrap-up.ts`). Reimplementing the trap, env prefix and exit-code handling in a second shell language means forking all three paths and putting the sentinel logic — exactly where silent hangs come from — into duplicated, hard-to-test code. Changing only the invocation keeps one command generator.

Letting the mux spawn the process directly would be cleaner still, but Herdr 0.8's `pane split` has no `--command`; only `pane run`, which types into the shell. (Zellij already gets a command surface via `createZellijCommandSurface`.) That looks like a Herdr-side feature request rather than something to solve here.

## Changes

- `src/mux/staged-shell.ts` (new) — pane-shell classification, interpreter resolution, staged command construction
- `src/mux/herdr.ts` — `getHerdrPaneProcessNames()` around `herdr pane process-info --pane <id>`, degrading to `[]` on older builds
- `src/mux/io.ts` — wiring only: resolve the plan, then stage, then send
- `test/mux/staged-shell.test.ts` (new) + registration in `test/test.ts`
- `README.md` — "Windows panes" section and a `PI_SUBAGENT_WIN_BASH` row in the env table

## Testing

- `node --test test/mux/staged-shell.test.ts` — 19 tests, all passing. They lock the exact emitted strings per shell, the `&` requirement, the absence of `rm -f` on the PowerShell path, quote doubling, the WSL skip, no-fallback on a bad `PI_SUBAGENT_WIN_BASH`, unknown-process fallback, and the throw-before-staging behaviour. No live mux needed.
- `npx tsc --noEmit` clean. `npx knip` reports nothing new versus `main`.
- Live on Windows 11 + Herdr `0.8.0-preview`: a fresh pane reported `pwsh.exe`; a staged script shaped like a real launch executed; its exit trap fired; the temp script was deleted. With a deliberately bogus `PI_SUBAGENT_WIN_BASH`, the launch threw and staged nothing. End to end, a real `scout` child now opens a pane and completes where it previously hung forever.

Two things worth flagging honestly:

- `npm test` as a whole hangs on Windows in `test/mux/mux.test.ts`, which writes `#!/bin/sh` fake mux binaries. I confirmed the identical hang on unpatched `main`, so it is pre-existing and not introduced here; the suites were run individually on this branch.
- `test/mux/herdr.test.ts` and `test/launch/herdr-interactive-launch.test.ts` assert the old `pane run … 'path'` shape. They still pass on POSIX CI, because the fake `herdr` has no `process-info` and detection falls back to POSIX. If Windows mux fakes are ever added, those assertions will need the new shape. I left them alone rather than churn tests your CI cannot exercise — happy to update them if you prefer.

## Known limitation

`herdr pane process-info` reports the pane's foreground process. On Windows a shell started *by hand* inside another shell is not reported separately, because ConPTY exposes a single foreground process group. A launch always targets a freshly created pane, so this does not affect the launch path; it is documented in the code comment rather than worked around.
